### PR TITLE
Add pop mode, four new flags, and statistical printing

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,6 +20,8 @@ Options:
         Starting index for transformations if applicable. Accepts ranges separated by '-'. (default 0)
   -k value
         Only keep items in a file.
+  -l value
+        Keeps output equal to or within a range of lengths. Accepts ranges separated by '-'. (default 0)
   -m int
         Minimum numerical frequency to include in output.
   -r value
@@ -33,6 +35,12 @@ Options:
   -u value
         Read additional URLs for input.
   -v    Show verbose output when possible.
+  -vs int
+        Maximum number of items to display in verbose statistics output. (default 25)
+  -vv
+        Show statistics output when possible.
+  -vvv
+        Show verbose statistics output when possible.
 
 The -f, -k, -r, -tf, and -u flags can be used multiple times.
 
@@ -74,7 +82,7 @@ Transformation Modes:
   -t swap -tf [file]
         Transforms input by swapping tokens with exact matches from a ':' separated file.
   -t pop -rm [uldsb]
-        Transforms input by generating tokens exluding characters not part of the mask.
+        Transforms input by generating tokens excluding characters not part of the mask.
 ```
 
 ## Getting Started:

--- a/README.md
+++ b/README.md
@@ -4,12 +4,10 @@
 - Transform input strings with various modes.
 - Creates `Hashcat` rules and masks from input strings.
 - Transforms input strings with a variety of functions for password cracking.
-- Accepts input from standard input, files, and URLs.
-- Works with multiple files and URLs for input and transformations.
+- Accepts input from multiple sources including; standard input, files, and URLs.
 - All transformations support multibyte characters.
 
 ```
-$ ptt -h
 Usage of Password Transformation Tool (ptt) version (0.0.0):
 
 ptt [options] [...]
@@ -36,7 +34,7 @@ Options:
         Read additional URLs for input.
   -v    Show verbose output when possible.
 
-The '-f', '-k', '-r', '-tf', and '-u' flags can be used multiple times.
+The -f, -k, -r, -tf, and -u flags can be used multiple times.
 
 Transformation Modes:
   -t append
@@ -75,6 +73,8 @@ Transformation Modes:
         Transforms input by swapping tokens with fuzzy matches from another file.
   -t swap -tf [file]
         Transforms input by swapping tokens with exact matches from a ':' separated file.
+  -t pop -rm [uldsb]
+        Transforms input by generating tokens exluding characters not part of the mask.
 ```
 
 ## Getting Started:

--- a/README.md
+++ b/README.md
@@ -93,7 +93,7 @@ TODO
 ```
 Slow method with Go installed:
 ```
-git clone https://github.com/JakeWnuk/ptt && cd ptt && go build ./main.go && mv ./ptt ~/go/bin/ptt && ptt
+git clone https://github.com/JakeWnuk/ptt && cd ptt && go build ./main.go && mv ./main ~/go/bin/ptt && ptt
 ```
 
 ### Docker:

--- a/README.md
+++ b/README.md
@@ -82,7 +82,7 @@ Transformation Modes:
 >[!NOTE]
 > This tool is still in development and considered early access. Please report any issues, bugs, or feature requests to the GitHub repository.
 
-Documentation on usage and examples can be found in the `/docs` directory or on the repository here: [link](https://github.com/JakeWnuk/ptt/docs)
+Documentation on usage and examples can be found in the `/docs` directory or on the repository here: [link](https://github.com/JakeWnuk/ptt/tree/main/docs)
 
 ## Install:
 

--- a/main.go
+++ b/main.go
@@ -32,7 +32,7 @@ func main() {
 		fmt.Fprintf(os.Stderr, "ptt [options] [...]\nAccepts standard input and/or additonal arguments.\n\n")
 		fmt.Fprintf(os.Stderr, "Options:\n")
 		flag.PrintDefaults()
-		fmt.Fprintf(os.Stderr, "\nThe '-f', '-k', '-r', '-tf', and '-u' flags can be used multiple times.\n")
+		fmt.Fprintf(os.Stderr, "\nThe -f, -k, -r, -tf, and -u flags can be used multiple times.\n")
 		fmt.Fprintf(os.Stderr, "\nTransformation Modes:\n")
 		fmt.Fprintf(os.Stderr, "  -t append\n\tTransforms input into append rules.\n")
 		fmt.Fprintf(os.Stderr, "  -t append-remove\n\tTransforms input into append-remove rules.\n")
@@ -52,6 +52,7 @@ func main() {
 		fmt.Fprintf(os.Stderr, "  -t match -tf [file]\n\tTransforms input by keeping only strings with matching masks from a mask file.\n")
 		fmt.Fprintf(os.Stderr, "  -t fuzzy-swap -tf [file]\n\tTransforms input by swapping tokens with fuzzy matches from another file.\n")
 		fmt.Fprintf(os.Stderr, "  -t swap -tf [file]\n\tTransforms input by swapping tokens with exact matches from a ':' separated file.\n")
+		fmt.Fprintf(os.Stderr, "  -t pop -rm [uldsb]\n\tTransforms input by generating tokens exluding characters not part of the mask.\n")
 	}
 
 	// Define command line flags

--- a/pkg/format/format_test.go
+++ b/pkg/format/format_test.go
@@ -11,6 +11,7 @@ import (
 // ** Output Functions **
 // - RetainRemove()
 // - RemoveMinimumFrequency()
+// - RemoveLengthRange()
 //
 // ** Encoding Functions **
 // - EncodeInputMap()
@@ -23,6 +24,8 @@ import (
 // Functions without Unit Tests
 // ----------------------------------------------------------------------------
 // - PrintArraytoSTDOUT (Output Functions)
+// - PrintStatsToSTDOUT (Output Functions)
+// - CreateVerboseStats (Output Functions)
 
 // Unit Test for RetainRemove()
 func TestRetainRemove(t *testing.T) {
@@ -79,6 +82,37 @@ func TestRemoveMinimumFrequency(t *testing.T) {
 		result := RemoveMinimumFrequency(test.input, test.min)
 		if utils.CheckAreMapsEqual(result, test.output) == false {
 			t.Errorf("RemoveMinimumFrequency() failed - expected: %v, got: %v", test.output, result)
+		}
+	}
+}
+
+// Unit Test for RemoveLengthRange()
+func TestRemoveLengthRange(t *testing.T) {
+
+	// Define a test case struct
+	type testCase struct {
+		input  map[string]int
+		min    int
+		max    int
+		output map[string]int
+	}
+
+	type testCases []testCase
+
+	// Define a test case
+	tests := testCases{
+		{map[string]int{"a": 1, "bc": 2, "cde": 3, "defg": 4}, 1, 5, map[string]int{"a": 1, "bc": 2, "cde": 3, "defg": 4}},
+		{map[string]int{"a": 1, "bc": 2, "cde": 3, "defg": 4}, 1, 4, map[string]int{"a": 1, "bc": 2, "cde": 3, "defg": 4}},
+		{map[string]int{"a": 1, "bc": 2, "cde": 3, "defg": 4}, 1, 3, map[string]int{"a": 1, "bc": 2, "cde": 3}},
+		{map[string]int{"a": 1, "bc": 2, "cde": 3, "defg": 4}, 1, 2, map[string]int{"a": 1, "bc": 2}},
+		{map[string]int{"a": 1, "bc": 2, "cde": 3, "defg": 4}, 1, 1, map[string]int{"a": 1}},
+	}
+
+	// Run test cases
+	for _, test := range tests {
+		result := RemoveLengthRange(test.input, test.min, test.max)
+		if utils.CheckAreMapsEqual(result, test.output) == false {
+			t.Errorf("RemoveLengthRange() failed - expected: %v, got: %v", test.output, result)
 		}
 	}
 }

--- a/pkg/mask/mask.go
+++ b/pkg/mask/mask.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"ptt/pkg/utils"
 	"strings"
+	"unicode"
 )
 
 // ----------------------------------------------------------------------------
@@ -293,4 +294,55 @@ func MakeMatchedMaskedMap(input map[string]int, replacementMask string, maskMap 
 		}
 	}
 	return maskedMap
+}
+
+// BoundarySplitPopMap splits the index of the input map into tokens based on
+// the provided mask string provided and returns a new map with the tokens
+// as keys and the values as the values
+//
+// Args:
+//
+//	input (map[string]int): Input map
+//	replacementMask (string): Mask characters to apply
+//
+// Returns:
+//
+//	(map[string]int): Boundary split map
+func BoundarySplitPopMap(input map[string]int, replacementMask string) map[string]int {
+	result := make(map[string]int)
+	for s, _ := range input {
+		token := ""
+		var lastRuneType rune
+		var runeType rune
+		for _, r := range s {
+			switch {
+			case unicode.IsLower(r):
+				runeType = 'l'
+			case unicode.IsUpper(r):
+				runeType = 'u'
+			case unicode.IsDigit(r):
+				runeType = 'd'
+			// !\"#$%&\\()*+,-./:;<=>?@[\\]^_`{|}~'
+			case strings.ContainsRune("!\"#$%&\\()*+,-./:;<=>?@[\\]^_`{|}~'", r):
+				runeType = 's'
+			default:
+				runeType = 'b'
+			}
+
+			if (lastRuneType != 0 && lastRuneType != runeType) || !strings.ContainsRune(replacementMask, runeType) {
+				if token != "" {
+					result[token]++
+					token = ""
+				}
+			}
+			if strings.ContainsRune(replacementMask, runeType) {
+				token += string(r)
+			}
+			lastRuneType = runeType
+		}
+		if token != "" {
+			result[token]++
+		}
+	}
+	return result
 }

--- a/pkg/mask/mask_test.go
+++ b/pkg/mask/mask_test.go
@@ -22,6 +22,7 @@ import (
 //
 // ** Mask Utility Functions **
 // - MakeMatchedMaskedMap()
+// - BoundarySplitPopMap()
 //
 // ----------------------------------------------------------------------------
 // Functions without Unit Tests
@@ -253,6 +254,34 @@ func TestMakeMatchedMaskedMap(t *testing.T) {
 	for _, test := range tests {
 		output := MakeMatchedMaskedMap(test.input, test.replacements, test.masks)
 		if utils.CheckAreMapsEqual(output, test.output) == false {
+			t.Errorf("Test failed: %v inputted, %v expected, %v returned", test.input, test.output, output)
+		}
+	}
+}
+
+// Unit Test for BoundarySplitPopMap()
+func TestBoundarySplitPopMap(t *testing.T) {
+
+	// Define a test case struct
+	type testCase struct {
+		input        map[string]int
+		replacements string
+		output       map[string]int
+	}
+
+	type testCases []testCase
+
+	// Define test cases
+	tests := testCases{
+		{map[string]int{"abc123": 1, "ABC": 2, "ABCabc123!!!": 3}, "luds", map[string]int{"!!!": 1, "ABC": 2, "abc": 2, "123": 2}},
+		{map[string]int{"123ABC": 1, "123456ABC": 2, "1Z2X39": 3}, "d", map[string]int{"1": 1, "123": 1, "123456": 1, "2": 1, "39": 1}},
+		{map[string]int{"12🙂test": 1, "😀test": 2, "test😁": 3}, "b", map[string]int{"🙂": 1, "😀": 1, "😁": 1}},
+	}
+
+	// Run test cases
+	for _, test := range tests {
+		output := BoundarySplitPopMap(test.input, test.replacements)
+		if !utils.CheckAreMapsEqual(output, test.output) {
 			t.Errorf("Test failed: %v inputted, %v expected, %v returned", test.input, test.output, output)
 		}
 	}

--- a/pkg/transform/transform.go
+++ b/pkg/transform/transform.go
@@ -88,6 +88,8 @@ func TransformationController(input map[string]int, mode string, startingIndex i
 		output = ReplaceKeysInMap(input, transformationFilesMap)
 	case "pop", "split", "boundary-split", "boundary-pop", "pop-split", "split-pop":
 		output = mask.BoundarySplitPopMap(input, replacementMask)
+	default:
+		output = input
 	}
 
 	return output

--- a/pkg/transform/transform.go
+++ b/pkg/transform/transform.go
@@ -86,6 +86,8 @@ func TransformationController(input map[string]int, mode string, startingIndex i
 			os.Exit(1)
 		}
 		output = ReplaceKeysInMap(input, transformationFilesMap)
+	case "pop", "split", "boundary-split", "boundary-pop", "pop-split", "split-pop":
+		output = mask.BoundarySplitPopMap(input, replacementMask)
 	}
 
 	return output

--- a/pkg/utils/utils.go
+++ b/pkg/utils/utils.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"io"
 	"net/http"
+	"os"
 	"ptt/pkg/models"
 	"regexp"
 	"strings"
@@ -155,6 +156,7 @@ func ProcessURL(url string, ch chan<- string, wg *sync.WaitGroup) {
 
 		resp, err = http.Get(url)
 		if err != nil {
+			fmt.Fprintf(os.Stderr, "Error fetching URL %s\n", url)
 			continue
 		}
 		defer resp.Body.Close()


### PR DESCRIPTION
- Add `pop` mode which allows for the splitting of tokens based on character boundaries
- Add `-l` flag to control a length or length range for the output
- Add `-vv` and `-vvv` flags to print statistical output
- Added `-vs` flag to control the max print for the statistical output
