### PR TITLE
Update to v0.1.2

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@
 - All transformations support multibyte characters.
 
 ```
-Usage of Password Transformation Tool (ptt) version (0.1.1):
+Usage of Password Transformation Tool (ptt) version (0.1.2):
 
 ptt [options] [...]
 Accepts standard input and/or additonal arguments.

--- a/docs/USAGE.md
+++ b/docs/USAGE.md
@@ -224,9 +224,6 @@ Total Characters: 2758719
 Total Words: 585199
 Largest frequency: 29529
 Smallest frequency: 1
-Mean frequency: 1
-Median frequency: 1
-Mode frequency: 29529
 
 Category Counts:
 alphabetical: 496547

--- a/main.go
+++ b/main.go
@@ -15,7 +15,7 @@ import (
 	"github.com/jakewnuk/ptt/pkg/utils"
 )
 
-var version = "0.1.1"
+var version = "0.1.2"
 var wg sync.WaitGroup
 var mutex = &sync.Mutex{}
 var retain models.FileArgumentFlag

--- a/pkg/format/format.go
+++ b/pkg/format/format.go
@@ -154,9 +154,6 @@ func CreateVerboseStats(freq map[string]int) string {
 	stats += fmt.Sprintf("Total Words: %d\n", totalWords)
 	stats += fmt.Sprintf("Largest frequency: %d\n", p[0].Value)
 	stats += fmt.Sprintf("Smallest frequency: %d\n", p[len(p)-1].Value)
-	stats += fmt.Sprintf("Mean frequency: %d\n", p[len(p)/2].Value)
-	stats += fmt.Sprintf("Median frequency: %d\n", p[len(p)/2].Value)
-	stats += fmt.Sprintf("Mode frequency: %d", p[0].Value)
 
 	stats += "\n\nCategory Counts:\n"
 	for category, count := range categoryCounts {

--- a/pkg/rule/rule.go
+++ b/pkg/rule/rule.go
@@ -150,6 +150,13 @@ func FormatCharToIteratingRuleOutput(index int, strs ...string) (output string) 
 		}
 	}
 
+	if len(output)-3 >= 0 {
+		// allow for the last character to be a space for overwrite and insert rules
+		if output[len(output)-3:len(output)-2] == "o" || output[len(output)-3:len(output)-2] == "i" {
+			output = output + ":"
+		}
+	}
+
 	if output != "" && len(output) <= 93 {
 		return strings.TrimSpace(output)
 	}

--- a/pkg/utils/utils.go
+++ b/pkg/utils/utils.go
@@ -413,7 +413,7 @@ func ConvertMultiByteCharToIteratingRule(index int, str string) string {
 		output += " "
 	}
 
-	return strings.TrimSpace(output)
+	return output
 }
 
 // SplitBySeparatorString splits a string by a separator string and returns a slice

--- a/pkg/utils/utils_test.go
+++ b/pkg/utils/utils_test.go
@@ -270,10 +270,10 @@ func TestConvertMultiByteCharToIteratingRule(t *testing.T) {
 
 	// Define test cases
 	testCases := TestCases{
-		{0, "i0l i1o i2v i3e", "i0l i1o i2v i3e"},
-		{0, "i0a i1爱", "i0a i1\\xE7 i2\\x88 i3\\xB1"},
-		{1, "i1a i2愛", "i1a i2\\xE6 i3\\x84 i4\\x9B"},
-		{0, "i0爱 i3t i4e i5s i6t", "i0\\xE7 i1\\x88 i2\\xB1 i3t i4e i5s i6t"},
+		{0, "i0l i1o i2v i3e", "i0l i1o i2v i3e "},
+		{0, "i0a i1爱", "i0a i1\\xE7 i2\\x88 i3\\xB1 "},
+		{1, "i1a i2愛", "i1a i2\\xE6 i3\\x84 i4\\x9B "},
+		{0, "i0爱 i3t i4e i5s i6t", "i0\\xE7 i1\\x88 i2\\xB1 i3t i4e i5s i6t "},
 	}
 
 	// Run test cases


### PR DESCRIPTION
- [Change: Remove mean, median, and mode from -vvv](https://github.com/JakeWnuk/ptt/commit/53e79e6698c36d2b6dc0a2fd0a481b5725932442)
- [Bug Fix: Allow spaces at the end of i and o rules](https://github.com/JakeWnuk/ptt/commit/794b97fde089862adce4d11418f8cb7cfc3ae1e7)