### PR TITLE
V0.3.1

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,7 +40,7 @@ git clone https://github.com/JakeWnuk/ptt && cd ptt && docker build -t ptt . && 
 
 ### Usage:
 ```
-Usage of Password Transformation Tool (ptt) version (0.3.0):
+Usage of Password Transformation Tool (ptt) version (0.3.1):
 
 ptt [options] [...]
 Accepts standard input and/or additonal arguments.
@@ -60,7 +60,7 @@ These modify or filter the transformation mode.
   -k value
         Only keep items in a file.
   -l value
-        Length of input to accept into transformation. Accepts ranges separated by '-'.
+        Only output items of a certain length (does not adjust for rules). Accepts ranges separated by '-'.
   -m int
         Minimum numerical frequency to include in output.
   -n int

--- a/docs/USAGE.md
+++ b/docs/USAGE.md
@@ -117,7 +117,7 @@ These flags work with files and directories.
 - `-f`: Read additional files for input.
 - `-i`: Starting index for transformations if applicable. Accepts ranges separated by '-'.
 - `-k`: Only keep items in a file.
-- `-l`: Length of input to accept into transformation. Accepts ranges separated by '-'.
+- `-l`: Only output items of a certain length (does not adjust for rules). Accepts ranges separated by '-'.
 - `-m`: Minimum numerical frequency to include in output.
 - `-n`: Maximum number of items to display in verbose statistics output. (default 25)
 - `-o`: Output to JSON file in addition to stdout.

--- a/main.go
+++ b/main.go
@@ -134,7 +134,7 @@ func main() {
 
 	// Combine stdin with any additional files
 	if len(primaryMap) == 0 && len(readFilesMap) == 0 && len(readURLsMap) == 0 {
-		flag.Usage()
+		fmt.Fprintf(os.Stderr, "[!] No input provided. Exiting.\n")
 		return
 	} else if len(primaryMap) == 0 {
 		primaryMap = utils.CombineMaps(readFilesMap, readURLsMap)

--- a/main.go
+++ b/main.go
@@ -100,7 +100,7 @@ func main() {
 	flag.Var(&transformationFiles, "tf", "Read additional files for transformations if applicable.")
 	flag.Var(&templateFiles, "tp", "Read a template file for multiple transformations and operations.")
 	flag.Var(&intRange, "i", "Starting index for transformations if applicable. Accepts ranges separated by '-'.")
-	flag.Var(&lenRange, "l", "Length of input to accept into transformation. Accepts ranges separated by '-'.")
+	flag.Var(&lenRange, "l", "Only output items of a certain length (does not adjust for rules). Accepts ranges separated by '-'.")
 	flag.Var(&readURLs, "u", "Read additional URLs for input.")
 	flag.Parse()
 
@@ -142,11 +142,6 @@ func main() {
 		primaryMap = utils.CombineMaps(primaryMap, readFilesMap, readURLsMap)
 	}
 
-	// Remove items outside of length range if provided
-	if lenRange.Start > 0 || lenRange.End > 0 {
-		primaryMap = format.RemoveLengthRange(primaryMap, lenRange.Start, lenRange.End)
-	}
-
 	// Apply transformation if provided
 	if *transformation != "" && templateFiles == nil {
 		primaryMap = transform.TransformationController(primaryMap, *transformation, intRange.Start, intRange.End, *verbose, *replacementMask, transformationFilesMap, *bypassMap, *debugMode, *passPhraseWords)
@@ -174,6 +169,16 @@ func main() {
 		return
 	}
 
+	// Remove items under minimum frequency if provided
+	if *minimum > 0 {
+		primaryMap = format.RemoveMinimumFrequency(primaryMap, *minimum)
+	}
+
+	// Remove items outside of length range if provided
+	if lenRange.Start > 0 || lenRange.End > 0 {
+		primaryMap = format.RemoveLengthRange(primaryMap, lenRange.Start, lenRange.End)
+	}
+
 	// Process retain and remove maps if provided
 	if len(retainMap) > 0 || len(removeMap) > 0 {
 		primaryMap, err = format.RetainRemove(primaryMap, retainMap, removeMap, *debugMode)
@@ -181,11 +186,6 @@ func main() {
 			fmt.Fprintf(os.Stderr, "[!] Error processing retain and remove flags: %s\n", err)
 			return
 		}
-	}
-
-	// Remove items under minimum frequency if provided
-	if *minimum > 0 {
-		primaryMap = format.RemoveMinimumFrequency(primaryMap, *minimum)
 	}
 
 	// Print output to stdout

--- a/main.go
+++ b/main.go
@@ -15,7 +15,7 @@ import (
 	"github.com/jakewnuk/ptt/pkg/utils"
 )
 
-var version = "0.3.0"
+var version = "0.3.1"
 var wg sync.WaitGroup
 var mutex = &sync.Mutex{}
 var retain models.FileArgumentFlag

--- a/pkg/utils/utils.go
+++ b/pkg/utils/utils.go
@@ -287,7 +287,9 @@ func ProcessURL(url string, ch chan<- string, wg *sync.WaitGroup, parsingMode in
 		req.Header.Set("User-Agent", randomUserAgent)
 		resp, err = client.Do(req)
 		if err != nil {
-			fmt.Fprintf(os.Stderr, "[!] Error fetching URL %s\n", url)
+			if debugMode >= 1 {
+				fmt.Fprintf(os.Stderr, "[!] Error fetching URL %s\n", url)
+			}
 			continue
 		}
 		defer resp.Body.Close()
@@ -311,8 +313,10 @@ func ProcessURL(url string, ch chan<- string, wg *sync.WaitGroup, parsingMode in
 	var err error
 	body, err = io.ReadAll(resp.Body)
 	if err != nil {
-		fmt.Fprintf(os.Stderr, "[!] Error reading response body from URL %s\n", url)
-		os.Exit(1)
+		if debugMode >= 1 {
+			fmt.Fprintf(os.Stderr, "[!] Error reading response body from URL %s\n", url)
+		}
+		return
 	}
 	text := string(body)
 	text = html.UnescapeString(text)
@@ -325,7 +329,7 @@ func ProcessURL(url string, ch chan<- string, wg *sync.WaitGroup, parsingMode in
 		doc, err := html.Parse(strings.NewReader(text))
 		if err != nil {
 			fmt.Fprintf(os.Stderr, "[!] Error parsing HTML from URL %s\n", url)
-			os.Exit(1)
+			return
 		}
 
 		// Traverse the HTML tree and extract the text
@@ -350,16 +354,10 @@ func ProcessURL(url string, ch chan<- string, wg *sync.WaitGroup, parsingMode in
 		fmt.Fprintf(os.Stderr, "[?] URL: %s\n", url)
 		fmt.Fprintf(os.Stderr, "[?] Content-Type: %s\n", contentType)
 		fmt.Fprintf(os.Stderr, "[?] Parsing Mode: %d\n", parsingMode)
-		if resp.StatusCode != http.StatusOK {
-			fmt.Fprintf(os.Stderr, "[!] Error fetching URL %s\n", url)
-		}
 	} else if debugMode == 2 {
 		fmt.Fprintf(os.Stderr, "[?] URL: %s\n", url)
 		fmt.Fprintf(os.Stderr, "[?] Content-Type: %s\n", contentType)
 		fmt.Fprintf(os.Stderr, "[?] Parsing Mode: %d\n", parsingMode)
-		if resp.StatusCode != http.StatusOK {
-			fmt.Fprintf(os.Stderr, "[?] Error fetching URL %s\n", url)
-		}
 		fmt.Fprintf(os.Stderr, "[?] Line Count: %d\n", len(lines))
 		fmt.Fprintf(os.Stderr, "[?] Sample Lines:\n")
 		for i := 0; i < 5; i++ {

--- a/pkg/utils/utils.go
+++ b/pkg/utils/utils.go
@@ -253,7 +253,6 @@ func ProcessURL(url string, ch chan<- string, wg *sync.WaitGroup, parsingMode in
 
 	var resp *http.Response
 	throttleInterval := 30
-	throttleBodyDetected := false
 	body := []byte{}
 	source := rand.NewSource(time.Now().UnixNano())
 	r := rand.New(source)
@@ -278,7 +277,6 @@ func ProcessURL(url string, ch chan<- string, wg *sync.WaitGroup, parsingMode in
 	}
 
 	for attempts := 0; attempts <= maxRetries; attempts++ {
-		fmt.Fprintf(os.Stderr, "[+] Requesting %s. Attempt [%d/%d].\n", url, attempts, maxRetries)
 
 		// Set a random user agent
 		randomUserAgent := userAgents[r.Intn(len(userAgents))]
@@ -301,7 +299,7 @@ func ProcessURL(url string, ch chan<- string, wg *sync.WaitGroup, parsingMode in
 			throttleInterval++
 		}
 
-		fmt.Fprintf(os.Stderr, "[+] Response Code: %s. Content-Type: %s. Throttle Body Detected: %t.\n", resp.Status, resp.Header.Get("Content-Type"), throttleBodyDetected)
+		fmt.Fprintf(os.Stderr, "[+] Requested %s. Attempt [%d/%d]. Response Code: %s. Content-Type: %s. \n", url, attempts, maxRetries, resp.Status, resp.Header.Get("Content-Type"))
 		if resp.StatusCode == http.StatusTooManyRequests {
 			time.Sleep(time.Second * time.Duration(throttleInterval) * time.Duration(r.Intn(10)))
 			continue

--- a/pkg/utils/utils.go
+++ b/pkg/utils/utils.go
@@ -252,7 +252,7 @@ func ProcessURL(url string, ch chan<- string, wg *sync.WaitGroup, parsingMode in
 	defer wg.Done()
 
 	var resp *http.Response
-	throttleInterval := 10
+	throttleInterval := 30
 	throttleBodyDetected := false
 	body := []byte{}
 	source := rand.NewSource(time.Now().UnixNano())
@@ -274,7 +274,7 @@ func ProcessURL(url string, ch chan<- string, wg *sync.WaitGroup, parsingMode in
 	}
 
 	if sleepOnStart {
-		time.Sleep(time.Second * time.Duration(throttleInterval) * time.Duration(r.Float64()))
+		time.Sleep(time.Second * time.Duration(throttleInterval) * time.Duration(r.Intn(10)))
 	}
 
 	for attempts := 0; attempts <= maxRetries; attempts++ {
@@ -315,7 +315,7 @@ func ProcessURL(url string, ch chan<- string, wg *sync.WaitGroup, parsingMode in
 
 		fmt.Fprintf(os.Stderr, "[+] Response Code: %s. Content-Type: %s. Throttle Body Detected: %t.\n", resp.Status, resp.Header.Get("Content-Type"), throttleBodyDetected)
 		if resp.StatusCode == http.StatusTooManyRequests || throttleBodyDetected {
-			time.Sleep(time.Second * time.Duration(throttleInterval))
+			time.Sleep(time.Second * time.Duration(throttleInterval) * time.Duration(r.Intn(10)))
 			continue
 		}
 

--- a/pkg/utils/utils.go
+++ b/pkg/utils/utils.go
@@ -314,7 +314,7 @@ func ProcessURL(url string, ch chan<- string, wg *sync.WaitGroup, parsingMode in
 			continue
 		}
 
-		if resp.StatusCode != http.StatusOK || resp.StatusCode != http.StatusNotFound {
+		if resp.StatusCode != http.StatusOK && resp.StatusCode != http.StatusNotFound {
 			if resp.StatusCode == http.StatusServiceUnavailable || resp.StatusCode == http.StatusUnauthorized || resp.StatusCode == http.StatusForbidden || resp.StatusCode == http.StatusBadRequest || resp.StatusCode == http.StatusMethodNotAllowed {
 				attempts = maxRetries + 1
 

--- a/pkg/utils/utils.go
+++ b/pkg/utils/utils.go
@@ -314,8 +314,8 @@ func ProcessURL(url string, ch chan<- string, wg *sync.WaitGroup, parsingMode in
 			continue
 		}
 
-		if resp.StatusCode != http.StatusOK {
-			if resp.StatusCode == http.StatusServiceUnavailable || resp.StatusCode == http.StatusUnauthorized || resp.StatusCode == http.StatusForbidden {
+		if resp.StatusCode != http.StatusOK || resp.StatusCode != http.StatusNotFound {
+			if resp.StatusCode == http.StatusServiceUnavailable || resp.StatusCode == http.StatusUnauthorized || resp.StatusCode == http.StatusForbidden || resp.StatusCode == http.StatusBadRequest || resp.StatusCode == http.StatusMethodNotAllowed {
 				attempts = maxRetries + 1
 
 				if debugMode >= 2 {

--- a/pkg/utils/utils.go
+++ b/pkg/utils/utils.go
@@ -466,7 +466,8 @@ func ProcessURL(url string, ch chan<- string, wg *sync.WaitGroup, parsingMode in
 				fourGrams := GenerateNGrams(sentence, 4)
 				fiveGrams := GenerateNGrams(sentence, 5)
 				sixGrams := GenerateNGrams(sentence, 6)
-				allNGrams := append(twoGrams, append(threeGrams, append(fourGrams, append(fiveGrams, sixGrams...)...)...)...)
+				sevenGrams := GenerateNGrams(sentence, 7)
+				allNGrams := append(twoGrams, append(threeGrams, append(fourGrams, append(fiveGrams, append(sixGrams, sevenGrams...)...)...)...)...)
 				for _, nGram := range allNGrams {
 					if nGram != "" {
 						nGram = strings.TrimSpace(nGram)

--- a/pkg/utils/utils.go
+++ b/pkg/utils/utils.go
@@ -316,7 +316,7 @@ func ProcessURL(url string, ch chan<- string, wg *sync.WaitGroup, parsingMode in
 		if debugMode >= 1 {
 			fmt.Fprintf(os.Stderr, "[!] Error reading response body from URL %s\n", url)
 		}
-		return
+		os.Exit(1)
 	}
 	text := string(body)
 	text = html.UnescapeString(text)
@@ -329,7 +329,7 @@ func ProcessURL(url string, ch chan<- string, wg *sync.WaitGroup, parsingMode in
 		doc, err := html.Parse(strings.NewReader(text))
 		if err != nil {
 			fmt.Fprintf(os.Stderr, "[!] Error parsing HTML from URL %s\n", url)
-			return
+			os.Exit(1)
 		}
 
 		// Traverse the HTML tree and extract the text


### PR DESCRIPTION
- added rate limiting detections to -u
- added more feedback by default for -u
- reduce number of active requests for -u
- unified response status codes for -u
- modified -u with more checks for poor urls and auto back offs restricted content
- changed some debug verbosity requirements for -u
- added more ngram parsing for -u
- added sleep before some requests when the same domain is examined for -u
- added improved url pasrsing for -u
- added more verbose feedback for -u
- new -l flag was bad so removed and reverted