### PR TITLE
V0.3.3

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,7 +40,7 @@ git clone https://github.com/JakeWnuk/ptt && cd ptt && docker build -t ptt . && 
 
 ### Usage:
 ```
-Usage of Password Transformation Tool (ptt) version (0.3.2):
+Usage of Password Transformation Tool (ptt) version (0.3.3):
 
 ptt [options] [...]
 Accepts standard input and/or additonal arguments.
@@ -64,7 +64,7 @@ These modify or filter the transformation mode.
   -m int
         Minimum numerical frequency to include in output.
   -n int
-        Maximum number of items to return in output. 
+        Maximum number of items to return in output.
   -o string
         Output to JSON file in addition to stdout.
   -p int
@@ -87,7 +87,7 @@ These modify or filter the transformation mode.
   -vvv
         Show verbose statistics output when possible.
   -w int
-        Number of words to generate for passphrases if applicable.
+        Number of words to use for a transformation if applicable.
 -------------------------------------------------------------------------------------------------------------
 Transformation Modes:
 These create or alter based on the selected mode.
@@ -114,6 +114,8 @@ These create or alter based on the selected mode.
         Transforms input by swapping tokens from a partial mask file and a input file.
   -t passphrase -w [words] -tf [file]
         Transforms input by randomly generating passphrases with a given number of words and separators from a file.
+  -t regram -w [words]
+        Transforms input by 'regramming' sentences into new n-grams with a given number of words.
   -t replace-all -tf [file]
         Transforms input by replacing all strings with all matches from a ':' separated file.
   -t rule-append

--- a/docs/USAGE.md
+++ b/docs/USAGE.md
@@ -1,5 +1,5 @@
 # Password Transformation Tool (PTT) Usage Guide
-## Version 0.3.0
+## Version 0.3.3
 
 ### Table of Contents
 #### Getting Started
@@ -37,6 +37,7 @@
 2. [Encoding and Decoding](#encoding-and-decoding)
 3. [Hex and Dehex](#hex-and-dehex)
 4. [Substrings](#substrings)
+5. [Regram](#regram)
 
 ## Getting Started
 
@@ -112,25 +113,46 @@ their collective values combined. The rest of the flags can only be used once.
 These flags work with files and directories.
 
 #### Options:
-- `-b`: Bypass map creation and use stdout as primary output.
-- `-d`: Enable debug mode with verbosity levels [0-2].
-- `-f`: Read additional files for input.
-- `-i`: Starting index for transformations if applicable. Accepts ranges separated by '-'.
-- `-k`: Only keep items in a file.
-- `-l`: Only output items of a certain length (does not adjust for rules). Accepts ranges separated by '-'.
-- `-m`: Minimum numerical frequency to include in output.
-- `-n`: Maximum number of items to return in output.
-- `-o`: Output to JSON file in addition to stdout.
-- `-p`: Change parsing mode for URL input. [0 = Strict, 1 = Permissive, 2 = Maximum].
-- `-r`: Only keep items not in a file.
-- `-rm`: Replacement mask for transformations if applicable. (default "uldsbt")
-- `-t`: Transformation to apply to input.
-- `-tf`: Read additional files for transformations if applicable.
-- `-tp`: Read a template file for multiple transformations and operations.
-- `-u`: Read additional URLs for input.
-- `-v`: Show verbose output when possible.
-- `-vv`: Show statistics output when possible.
-- `-vvv`: Show verbose statistics output when possible.
+```
+  -b    Bypass map creation and use stdout as primary output.
+  -d int
+        Enable debug mode with verbosity levels [0-2].
+  -f value
+        Read additional files for input.
+  -i value
+        Starting index for transformations if applicable. Accepts ranges separated by '-'.
+  -k value
+        Only keep items in a file.
+  -l value
+        Only output items of a certain length (does not adjust for rules). Accepts ranges separated by '-'.
+  -m int
+        Minimum numerical frequency to include in output.
+  -n int
+        Maximum number of items to return in output.
+  -o string
+        Output to JSON file in addition to stdout.
+  -p int
+        Change parsing mode for URL input. [0 = Strict, 1 = Permissive, 2 = Maximum] [0-2].
+  -r value
+        Only keep items not in a file.
+  -rm string
+        Replacement mask for transformations if applicable. (default "uldsbt")
+  -t string
+        Transformation to apply to input.
+  -tf value
+        Read additional files for transformations if applicable.
+  -tp value
+        Read a template file for multiple transformations and operations.
+  -u value
+        Read additional URLs for input.
+  -v    Show verbose output when possible.
+  -vv
+        Show statistics output when possible.
+  -vvv
+        Show verbose statistics output when possible.
+  -w int
+        Number of words to use for a transformation if applicable.
+```
 
 #### Transformations:
 The following transformations can be used with the `-t` flag:
@@ -157,6 +179,8 @@ The following transformations can be used with the `-t` flag:
         Transforms input by swapping tokens from a partial mask file and a input file.
   -t passphrase -w [words] -tf [file]
         Transforms input by randomly generating passphrases with a given number of words and separators from a file.
+  -t regram -w [words]
+        Transforms input by 'regramming' sentences into new n-grams with a given number of words.
   -t replace-all -tf [file]
         Transforms input by replacing all strings with all matches from a ':' separated file.
   -t rule-append
@@ -649,4 +673,15 @@ changed to the length of the input.
 
 This transformation can be used to extract specific parts of the input for
 further processing.
+
+### Regram
+This mode allows 'regramming' sentences into new n-grams with a given number of words. The syntax is as follows:
+```
+ptt -f <input_file> -t regram -w <word_count>
+```
+The `regram` transformation will generate new n-grams from the input by
+combining words from the input. The number of words to use in the n-gram is
+specified by the `-w` flag. The output will be the new n-grams generated from
+the input.
+
 

--- a/main.go
+++ b/main.go
@@ -65,6 +65,7 @@ func main() {
 			"passphrase -w [words] -tf [file]":   "Transforms input by randomly generating passphrases with a given number of words and separators from a file.",
 			"substring -i [index]":               "Transforms input by extracting substrings starting at index and ending at index.",
 			"replace-all -tf [file]":             "Transforms input by replacing all strings with all matches from a ':' separated file.",
+			"regram -w [words]":                  "Transforms input by 'regramming' sentences into new n-grams with a given number of words.",
 		}
 
 		// Sort and print transformation modes
@@ -93,7 +94,7 @@ func main() {
 	bypassMap := flag.Bool("b", false, "Bypass map creation and use stdout as primary output.")
 	debugMode := flag.Int("d", 0, "Enable debug mode with verbosity levels [0-2].")
 	URLParsingMode := flag.Int("p", 0, "Change parsing mode for URL input. [0 = Strict, 1 = Permissive, 2 = Maximum] [0-2].")
-	passPhraseWords := flag.Int("w", 0, "Number of words to generate for passphrases if applicable.")
+	passPhraseWords := flag.Int("w", 0, "Number of words to use for a transformation if applicable.")
 	flag.Var(&retain, "k", "Only keep items in a file.")
 	flag.Var(&remove, "r", "Only keep items not in a file.")
 	flag.Var(&readFiles, "f", "Read additional files for input.")

--- a/main.go
+++ b/main.go
@@ -15,7 +15,7 @@ import (
 	"github.com/jakewnuk/ptt/pkg/utils"
 )
 
-var version = "0.3.2"
+var version = "0.3.3"
 var wg sync.WaitGroup
 var mutex = &sync.Mutex{}
 var retain models.FileArgumentFlag

--- a/pkg/rule/rule.go
+++ b/pkg/rule/rule.go
@@ -122,7 +122,7 @@ func FormatCharToRuleOutput(strs ...string) (output string) {
 		output = output[:len(output)-1] + ":"
 	}
 
-	if output != "" && len(output) <= 93 {
+	if output != "" && len(output) < 93 {
 		return strings.TrimSpace(output)
 	}
 
@@ -157,7 +157,7 @@ func FormatCharToIteratingRuleOutput(index int, strs ...string) (output string) 
 		}
 	}
 
-	if output != "" && len(output) <= 93 {
+	if output != "" && len(output) < 93 {
 		return strings.TrimSpace(output)
 	}
 

--- a/pkg/utils/utils.go
+++ b/pkg/utils/utils.go
@@ -40,8 +40,8 @@ import (
 //	(map[string]int): A map of words from the files
 func ReadFilesToMap(fs models.FileSystem, filenames []string) map[string]int {
 	wordMap := make(map[string]int)
-	// 2 GB read buffer
-	chunkSize := int64(2 * 1024 * 1024 * 1024)
+	// 4 GB read buffer
+	chunkSize := int64(4 * 1024 * 1024 * 1024)
 
 	i := 0
 	for i < len(filenames) {

--- a/pkg/utils/utils.go
+++ b/pkg/utils/utils.go
@@ -40,8 +40,8 @@ import (
 //	(map[string]int): A map of words from the files
 func ReadFilesToMap(fs models.FileSystem, filenames []string) map[string]int {
 	wordMap := make(map[string]int)
-	// 5 GB read buffer
-	chunkSize := int64(5 * 1024 * 1024 * 1024)
+	// 2 GB read buffer
+	chunkSize := int64(2 * 1024 * 1024 * 1024)
 
 	i := 0
 	for i < len(filenames) {


### PR DESCRIPTION
- Implemented a read buffer for `-f` reading of 4 GB. This means that when using `-f` a large 4 GB buffer will be allocated and reused for loading large files. 
    - This is overkill but results in large time savings when processing files. If the buffer is under used, it is reallocated. This may have an impact on users with low total RAM installed, but only `-f` allocates this buffer and I would imagine users would have ~ 8 GB at minimum. 
- Max rule size is now less than 93 instead of equal to
- Added the new transformation mode `regram`. This mode takes in sentences similar to `-u` and "regrams" them into strings with a given number of words.