### PR TITLE
v0.3.4

### DIFF
--- a/docs/USAGE.md
+++ b/docs/USAGE.md
@@ -1,5 +1,5 @@
 # Password Transformation Tool (PTT) Usage Guide
-## Version 0.3.3
+## Version 0.3.4
 
 ### Table of Contents
 #### Getting Started
@@ -32,7 +32,7 @@
 5. [Token Swapping](#token-swapping)
 6. [Passphrases](#passphrases)
 
-### Misc Creation Guide
+### Misc. Creation Guide
 1. [Misc Creation Introduction](#misc-creation-introduction)
 2. [Encoding and Decoding](#encoding-and-decoding)
 3. [Hex and Dehex](#hex-and-dehex)

--- a/docs/USAGE.md
+++ b/docs/USAGE.md
@@ -592,6 +592,39 @@ This mode is most similar to token-swapping in that it generates new
 candidates by using masks. However, it is unique in that it uses partial
 masks to limit the swap positions from prior applications.
 
+#### Token Swapping Example
+```bash
+$ cat pass.lst
+love@123
+@123love
+
+$ cat retain.txt
+love
+```
+
+Create retain masks:
+```bash
+$ ptt -f pass.lst -tf retain.txt -t mask-retain | tee retained.mask
+?s?d?d?dlove
+love?s?d?d?d
+```
+
+Then swap on them with matching values:
+```bash
+$ cat swap.lst
+$333
+#888
+#123
+
+$ ptt -f retained.mask -tf swap.lst -t mask-swap
+#123love
+$333love
+love$333
+love#888
+love#123
+#888love
+```
+
 ### Passphrases
 The `passphrase` module generates passphrases by reforming sentences. The syntax is as follows:
 ```

--- a/main.go
+++ b/main.go
@@ -117,10 +117,24 @@ func main() {
 
 	// Parse any retain, remove, or transformation file arguments
 	fs := &models.RealFileSystem{}
-	retainMap := utils.ReadFilesToMap(fs, retain)
-	removeMap := utils.ReadFilesToMap(fs, remove)
-	readFilesMap := utils.ReadFilesToMap(fs, readFiles)
-	transformationFilesMap := utils.ReadFilesToMap(fs, transformationFiles)
+	var retainMap map[string]int
+	var removeMap map[string]int
+	var readFilesMap map[string]int
+	var transformationFilesMap map[string]int
+
+	if retain != nil {
+		retainMap = utils.ReadFilesToMap(fs, retain)
+	}
+	if remove != nil {
+		removeMap = utils.ReadFilesToMap(fs, remove)
+	}
+	if readFiles != nil {
+		readFilesMap = utils.ReadFilesToMap(fs, readFiles)
+	}
+	if transformationFiles != nil {
+		transformationFilesMap = utils.ReadFilesToMap(fs, transformationFiles)
+	}
+
 	transformationTemplateArray := utils.ReadJSONToArray(fs, templateFiles)
 	readURLsMap, err := utils.ReadURLsToMap(readURLs, *URLParsingMode, *debugMode)
 	if err != nil {

--- a/main.go
+++ b/main.go
@@ -138,7 +138,7 @@ func main() {
 	transformationTemplateArray := utils.ReadJSONToArray(fs, templateFiles)
 	readURLsMap, err := utils.ReadURLsToMap(readURLs, *URLParsingMode, *debugMode)
 	if err != nil {
-		fmt.Fprintf(os.Stderr, "[!] Error reading URLs: %s\n", err)
+		fmt.Fprintf(os.Stderr, "[!] Error reading URLs: %s.\n", err)
 		return
 	}
 
@@ -147,7 +147,7 @@ func main() {
 	if (stat.Mode() & os.ModeCharDevice) == 0 {
 		primaryMap, err = utils.LoadStdinToMap(bufio.NewScanner(os.Stdin))
 		if err != nil {
-			fmt.Fprintf(os.Stderr, "[!] Error reading from stdin: %s\n", err)
+			fmt.Fprintf(os.Stderr, "[!] Error reading from stdin: %s.\n", err)
 			return
 		}
 	}
@@ -218,7 +218,7 @@ func main() {
 	if len(retainMap) > 0 || len(removeMap) > 0 {
 		primaryMap, err = format.RetainRemove(primaryMap, retainMap, removeMap, *debugMode)
 		if err != nil {
-			fmt.Fprintf(os.Stderr, "[!] Error processing retain and remove flags: %s\n", err)
+			fmt.Fprintf(os.Stderr, "[!] Error processing retain and remove flags: %s.\n", err)
 			return
 		}
 	}
@@ -239,14 +239,14 @@ func main() {
 
 	// Print output location if provided
 	if *jsonOutput != "" {
-		fmt.Fprintf(os.Stderr, "[*] Saving output to JSON file: %s\n", *jsonOutput)
+		fmt.Fprintf(os.Stderr, "[*] Saving output to JSON file: %s.\n", *jsonOutput)
 	}
 
 	// Save output to JSON if provided
 	if *jsonOutput != "" {
 		err = format.SaveArrayToJSON(*jsonOutput, primaryMap)
 		if err != nil {
-			fmt.Fprintf(os.Stderr, "[!] Error saving output to JSON: %s\n", err)
+			fmt.Fprintf(os.Stderr, "[!] Error saving output to JSON: %s.\n", err)
 			return
 		}
 	}

--- a/main.go
+++ b/main.go
@@ -107,7 +107,7 @@ func main() {
 
 	// Bypass map creation if requested
 	if *bypassMap {
-		fmt.Fprintf(os.Stderr, "[*] Bypassing map creation and using stdout as primary output. Options are disabled.\n")
+		fmt.Fprintf(os.Stderr, "[*] Bypassing map creation and using standard output as primary output. Options are disabled.\n")
 	}
 
 	// Print debug information if requested
@@ -147,7 +147,7 @@ func main() {
 	if (stat.Mode() & os.ModeCharDevice) == 0 {
 		primaryMap, err = utils.LoadStdinToMap(bufio.NewScanner(os.Stdin))
 		if err != nil {
-			fmt.Fprintf(os.Stderr, "[!] Error reading from stdin: %s.\n", err)
+			fmt.Fprintf(os.Stderr, "[!] Error reading from standard input: %s.\n", err)
 			return
 		}
 	}
@@ -161,6 +161,8 @@ func main() {
 	} else {
 		primaryMap = utils.CombineMaps(primaryMap, readFilesMap, readURLsMap)
 	}
+
+	fmt.Fprintf(os.Stderr, "[*] All content done loading.")
 
 	// Apply transformation if provided
 	if *transformation != "" && templateFiles == nil {
@@ -227,6 +229,8 @@ func main() {
 	if *outputVerboseMax > 0 {
 		primaryMap = format.FilterTopN(primaryMap, *outputVerboseMax)
 	}
+
+	fmt.Fprintf(os.Stderr, "[*] Task complete with %d unique results.\n", len(primaryMap))
 
 	// Print output to stdout
 	if *verbose3 {

--- a/pkg/format/format.go
+++ b/pkg/format/format.go
@@ -86,7 +86,7 @@ func PrintStatsToSTDOUT(freq map[string]int, verbose bool, max int) {
 	}
 
 	if len(p) == 0 {
-		fmt.Println("No items to print!")
+		fmt.Println("[!] No items to print!")
 		return
 	}
 
@@ -117,7 +117,7 @@ func PrintStatsToSTDOUT(freq map[string]int, verbose bool, max int) {
 	// Print the top items
 	for index, value := range p[0:max] {
 		if value.Value == 1 && index == 0 {
-			fmt.Println("No items with a frequency greater than 1!")
+			fmt.Println("[!] No items with a frequency greater than 1!")
 			break
 		}
 		padding := longest - len(value.Key)

--- a/pkg/rule/rule.go
+++ b/pkg/rule/rule.go
@@ -319,13 +319,13 @@ func InsertRules(items map[string]int, index string, end string, bypass bool, de
 	returnMap = make(map[string]int)
 	i, err := strconv.Atoi(index)
 	if err != nil {
-		fmt.Printf("Error: %s\n", err)
+		fmt.Printf("[!] Error: %s\n", err)
 		os.Exit(1)
 	}
 
 	e, err := strconv.Atoi(end)
 	if err != nil {
-		fmt.Printf("Error: %s\n", err)
+		fmt.Printf("[!] Error: %s\n", err)
 		os.Exit(1)
 	}
 
@@ -369,13 +369,13 @@ func OverwriteRules(items map[string]int, index string, end string, bypass bool,
 	returnMap = make(map[string]int)
 	i, err := strconv.Atoi(index)
 	if err != nil {
-		fmt.Printf("Error: %s\n", err)
+		fmt.Printf("[!] Error: %s\n", err)
 		os.Exit(1)
 	}
 
 	e, err := strconv.Atoi(end)
 	if err != nil {
-		fmt.Printf("Error: %s\n", err)
+		fmt.Printf("[!] Error: %s\n", err)
 		os.Exit(1)
 	}
 
@@ -419,13 +419,13 @@ func ToggleRules(items map[string]int, index string, end string, bypass bool, de
 	returnMap = make(map[string]int)
 	i, err := strconv.Atoi(index)
 	if err != nil {
-		fmt.Printf("Error: %s\n", err)
+		fmt.Printf("[!] Error: %s\n", err)
 		os.Exit(1)
 	}
 
 	e, err := strconv.Atoi(end)
 	if err != nil {
-		fmt.Printf("Error: %s\n", err)
+		fmt.Printf("[!] Error: %s\n", err)
 		os.Exit(1)
 	}
 

--- a/pkg/transform/transform.go
+++ b/pkg/transform/transform.go
@@ -109,13 +109,14 @@ func TransformationController(input map[string]int, mode string, startingIndex i
 	case "mask-pop", "pop":
 		output = mask.BoundarySplitPopMap(input, replacementMask, bypass, functionDebug)
 	case "mask-swap":
+		fmt.Fprintf(os.Stderr, "[!] This transformation mode requres a retain mask file to use for swapping\n")
 		if len(transformationFilesMap) == 0 {
-			fmt.Fprintf(os.Stderr, "[!] Mask-swap operations require use of one or more -tf flags to specify one or more files")
-			fmt.Fprintf(os.Stderr, "[!] This transformation mode requres a retain mask file to use for swapping")
+			fmt.Fprintf(os.Stderr, "[!] Mask-swap operations require use of one or more -tf flags to specify one or more files\n")
 			os.Exit(1)
 		}
 		output = mask.ShuffleMap(input, replacementMask, transformationFilesMap, bypass, functionDebug)
 	case "passphrase":
+		fmt.Fprintf(os.Stderr, "[!] This transformation mode expects sentences separated by spaces\n")
 		if passphraseWords == 0 {
 			fmt.Fprintf(os.Stderr, "[!] Passphrase operations require use of the -w flag to specify the number of words to use\n")
 			os.Exit(1)
@@ -130,6 +131,7 @@ func TransformationController(input map[string]int, mode string, startingIndex i
 		}
 		output = ReplaceAllKeysInMap(input, transformationFilesMap, bypass, functionDebug)
 	case "regram":
+		fmt.Fprintf(os.Stderr, "[!] This transformation mode expects sentences separated by spaces\n")
 		if passphraseWords == 0 {
 			fmt.Fprintf(os.Stderr, "[!] Regram operations require use of the -w flag to specify the number of words to use\n")
 			os.Exit(1)

--- a/pkg/transform/transform.go
+++ b/pkg/transform/transform.go
@@ -46,14 +46,14 @@ func TransformationController(input map[string]int, mode string, startingIndex i
 
 	if debug > 0 {
 		fmt.Fprintf(os.Stderr, "[?] TransformationController: Starting debug mode:\n")
-		fmt.Fprintf(os.Stderr, "[?] TransformationController: Running in mode %s\n", mode)
-		fmt.Fprintf(os.Stderr, "[?] TransformationController: Starting index is %d\n", startingIndex)
-		fmt.Fprintf(os.Stderr, "[?] TransformationController: Ending index is %d\n", endingIndex)
-		fmt.Fprintf(os.Stderr, "[?] TransformationController: Replacement mask is %s\n", replacementMask)
-		fmt.Fprintf(os.Stderr, "[?] TransformationController: Bypass is %t\n", bypass)
-		fmt.Fprintf(os.Stderr, "[?] TransformationController: Verbose is %t\n", verbose)
-		fmt.Fprintf(os.Stderr, "[?] TransformationController: Transformation files map is %v\n", transformationFilesMap)
-		fmt.Fprintf(os.Stderr, "[?] TransformationController: Input map is %v\n", input)
+		fmt.Fprintf(os.Stderr, "[?] TransformationController: Running in mode %s.\n", mode)
+		fmt.Fprintf(os.Stderr, "[?] TransformationController: Starting index is %d.\n", startingIndex)
+		fmt.Fprintf(os.Stderr, "[?] TransformationController: Ending index is %d.\n", endingIndex)
+		fmt.Fprintf(os.Stderr, "[?] TransformationController: Replacement mask is %s.\n", replacementMask)
+		fmt.Fprintf(os.Stderr, "[?] TransformationController: Bypass is %t.\n", bypass)
+		fmt.Fprintf(os.Stderr, "[?] TransformationController: Verbose is %t.\n", verbose)
+		fmt.Fprintf(os.Stderr, "[?] TransformationController: Transformation files map is %v.\n", transformationFilesMap)
+		fmt.Fprintf(os.Stderr, "[?] TransformationController: Input map is %v.\n", input)
 		fmt.Fprintf(os.Stderr, "[?] TransformationController: Starting transformation...\n")
 	}
 
@@ -89,36 +89,36 @@ func TransformationController(input map[string]int, mode string, startingIndex i
 		output = mask.RemoveMaskedCharacters(input, replacementMask, bypass, functionDebug)
 	case "mask-retain", "retain":
 		if len(transformationFilesMap) == 0 {
-			fmt.Fprintf(os.Stderr, "[!] Retain masks require use of one or more -tf flags to specify one or more files\n")
+			fmt.Fprintf(os.Stderr, "[!] Retain masks require use of one or more -tf flags to specify one or more files.\n")
 			os.Exit(1)
 		}
 		output = mask.MakeRetainMaskedMap(input, replacementMask, transformationFilesMap, bypass, functionDebug)
 	case "mask-match", "match":
 		if len(transformationFilesMap) == 0 {
-			fmt.Fprintf(os.Stderr, "[!] Match masks require use of one or more -tf flags to specify one or more files\n")
+			fmt.Fprintf(os.Stderr, "[!] Match masks require use of one or more -tf flags to specify one or more files.\n")
 			os.Exit(1)
 		}
 		output = mask.MakeMatchedMaskedMap(input, replacementMask, transformationFilesMap, bypass, functionDebug)
 	case "swap", "swap-single":
 		if len(transformationFilesMap) == 0 {
-			fmt.Fprintf(os.Stderr, "[!] Swap operations require use of one or more -tf flags to specify one or more files\n")
-			fmt.Fprintf(os.Stderr, "[!] This transformation mode requires a ':' separated list of keys to swap\n")
+			fmt.Fprintf(os.Stderr, "[!] Swap operations require use of one or more -tf flags to specify one or more files.\n")
+			fmt.Fprintf(os.Stderr, "[!] This transformation mode requires a ':' separated list of keys to swap.\n")
 			os.Exit(1)
 		}
 		output = ReplaceKeysInMap(input, transformationFilesMap, bypass, functionDebug)
 	case "mask-pop", "pop":
 		output = mask.BoundarySplitPopMap(input, replacementMask, bypass, functionDebug)
 	case "mask-swap":
-		fmt.Fprintf(os.Stderr, "[!] This transformation mode requres a retain mask file to use for swapping\n")
+		fmt.Fprintf(os.Stderr, "[!] This transformation mode requres a retain mask file to use for swapping.\n")
 		if len(transformationFilesMap) == 0 {
-			fmt.Fprintf(os.Stderr, "[!] Mask-swap operations require use of one or more -tf flags to specify one or more files\n")
+			fmt.Fprintf(os.Stderr, "[!] Mask-swap operations require use of one or more -tf flags to specify one or more files.\n")
 			os.Exit(1)
 		}
 		output = mask.ShuffleMap(input, replacementMask, transformationFilesMap, bypass, functionDebug)
 	case "passphrase":
-		fmt.Fprintf(os.Stderr, "[!] This transformation mode expects sentences separated by spaces\n")
+		fmt.Fprintf(os.Stderr, "[!] This transformation mode expects sentences separated by spaces.\n")
 		if passphraseWords == 0 {
-			fmt.Fprintf(os.Stderr, "[!] Passphrase operations require use of the -w flag to specify the number of words to use\n")
+			fmt.Fprintf(os.Stderr, "[!] Passphrase operations require use of the -w flag to specify the number of words to use.\n")
 			os.Exit(1)
 		}
 		output = MakePassphraseMap(input, bypass, functionDebug, passphraseWords)
@@ -126,14 +126,14 @@ func TransformationController(input map[string]int, mode string, startingIndex i
 		output = utils.SubstringMap(input, startingIndex, endingIndex, bypass, functionDebug)
 	case "replace-all", "replace":
 		if len(transformationFilesMap) == 0 {
-			fmt.Fprintf(os.Stderr, "[!] Replace operations require use of one or more -tf flags to specify one or more files\n")
+			fmt.Fprintf(os.Stderr, "[!] Replace operations require use of one or more -tf flags to specify one or more files.\n")
 			os.Exit(1)
 		}
 		output = ReplaceAllKeysInMap(input, transformationFilesMap, bypass, functionDebug)
 	case "regram":
-		fmt.Fprintf(os.Stderr, "[!] This transformation mode expects sentences separated by spaces\n")
+		fmt.Fprintf(os.Stderr, "[!] This transformation mode expects sentences separated by spaces.\n")
 		if passphraseWords == 0 {
-			fmt.Fprintf(os.Stderr, "[!] Regram operations require use of the -w flag to specify the number of words to use\n")
+			fmt.Fprintf(os.Stderr, "[!] Regram operations require use of the -w flag to specify the number of words to use.\n")
 			os.Exit(1)
 		}
 		output = GenerateNGramMap(input, passphraseWords, bypass, functionDebug)
@@ -142,7 +142,7 @@ func TransformationController(input map[string]int, mode string, startingIndex i
 	}
 
 	if debug > 0 {
-		fmt.Fprintf(os.Stderr, "[?] TransformationController: Output map is %v\n", output)
+		fmt.Fprintf(os.Stderr, "[?] TransformationController: Output map is %v.\n", output)
 		fmt.Fprintf(os.Stderr, "[?] TransformationController: Transformation complete. Resuming output.\n")
 	}
 

--- a/pkg/transform/transform.go
+++ b/pkg/transform/transform.go
@@ -100,23 +100,23 @@ func TransformationController(input map[string]int, mode string, startingIndex i
 		}
 		output = mask.MakeMatchedMaskedMap(input, replacementMask, transformationFilesMap, bypass, functionDebug)
 	case "swap", "swap-single":
+		fmt.Fprintf(os.Stderr, "[*] This transformation mode requires a ':' separated list of keys to swap.\n")
 		if len(transformationFilesMap) == 0 {
 			fmt.Fprintf(os.Stderr, "[!] Swap operations require use of one or more -tf flags to specify one or more files.\n")
-			fmt.Fprintf(os.Stderr, "[!] This transformation mode requires a ':' separated list of keys to swap.\n")
 			os.Exit(1)
 		}
 		output = ReplaceKeysInMap(input, transformationFilesMap, bypass, functionDebug)
 	case "mask-pop", "pop":
 		output = mask.BoundarySplitPopMap(input, replacementMask, bypass, functionDebug)
 	case "mask-swap":
-		fmt.Fprintf(os.Stderr, "[!] This transformation mode requres a retain mask file to use for swapping.\n")
+		fmt.Fprintf(os.Stderr, "[*] This transformation mode requires a retain mask file to use for swapping.\n")
 		if len(transformationFilesMap) == 0 {
 			fmt.Fprintf(os.Stderr, "[!] Mask-swap operations require use of one or more -tf flags to specify one or more files.\n")
 			os.Exit(1)
 		}
 		output = mask.ShuffleMap(input, replacementMask, transformationFilesMap, bypass, functionDebug)
 	case "passphrase":
-		fmt.Fprintf(os.Stderr, "[!] This transformation mode expects sentences separated by spaces.\n")
+		fmt.Fprintf(os.Stderr, "[*] This transformation mode expects space separated content.\n")
 		if passphraseWords == 0 {
 			fmt.Fprintf(os.Stderr, "[!] Passphrase operations require use of the -w flag to specify the number of words to use.\n")
 			os.Exit(1)
@@ -131,7 +131,7 @@ func TransformationController(input map[string]int, mode string, startingIndex i
 		}
 		output = ReplaceAllKeysInMap(input, transformationFilesMap, bypass, functionDebug)
 	case "regram":
-		fmt.Fprintf(os.Stderr, "[!] This transformation mode expects sentences separated by spaces.\n")
+		fmt.Fprintf(os.Stderr, "[*] This transformation mode expects space separated content.\n")
 		if passphraseWords == 0 {
 			fmt.Fprintf(os.Stderr, "[!] Regram operations require use of the -w flag to specify the number of words to use.\n")
 			os.Exit(1)

--- a/pkg/utils/utils.go
+++ b/pkg/utils/utils.go
@@ -43,6 +43,7 @@ import (
 func ReadFilesToMap(fs models.FileSystem, filenames []string) map[string]int {
 	wordMap := make(map[string]int)
 	// 4 GB read buffer
+	fmt.Fprintf(os.Stderr, "[*] Creating file buffer...\n")
 	chunkSize := int64(4 * 1024 * 1024 * 1024)
 
 	i := 0

--- a/pkg/utils/utils.go
+++ b/pkg/utils/utils.go
@@ -981,7 +981,19 @@ func GenerateNGrams(text string, n int) []string {
 	return nGrams
 }
 
+// GeneratePassphrase generates a passphrase from a string of text
+// and returns a slice of passphrases
+//
+// Args:
+// text (string): The text to generate passphrases from
+// n (int): The number of words in the passphrase
+//
+// Returns:
+// []string: A slice of passphrases
 func GeneratePassphrase(text string, n int) []string {
+	text = strings.ReplaceAll(text, ".", "")
+	text = strings.ReplaceAll(text, ",", "")
+	text = strings.ReplaceAll(text, ";", "")
 	words := strings.Fields(text)
 	var passphrases []string
 
@@ -1031,6 +1043,10 @@ func GeneratePassphrase(text string, n int) []string {
 
 	passphrases = append(passphrases, strings.ReplaceAll(titleCaseWords, " ", ""))
 	passphrases = append(passphrases, strings.ReplaceAll(turkTitleCaseWords, " ", ""))
+	passphrases = append(passphrases, strings.ReplaceAll(titleCaseWords, " ", "-"))
+	passphrases = append(passphrases, strings.ReplaceAll(turkTitleCaseWords, " ", "-"))
+	passphrases = append(passphrases, strings.ReplaceAll(titleCaseWords, " ", "_"))
+	passphrases = append(passphrases, strings.ReplaceAll(turkTitleCaseWords, " ", "_"))
 	passphrases = append(passphrases, CAPSlowerPassphrase)
 	passphrases = append(passphrases, lowerCAPSPassphrase)
 	passphrases = append(passphrases, lowerl33tPassphrase)

--- a/pkg/utils/utils.go
+++ b/pkg/utils/utils.go
@@ -52,14 +52,14 @@ func ReadFilesToMap(fs models.FileSystem, filenames []string) map[string]int {
 		if IsFileSystemDirectory(filename) {
 			files, err := GetFilesInDirectory(filename)
 			if err != nil {
-				fmt.Fprintf(os.Stderr, "[!] Error reading the directory %v: %v\n", filename, err)
+				fmt.Fprintf(os.Stderr, "[!] Error reading the directory %v: %v.\n", filename, err)
 				os.Exit(1)
 			}
 			filenames = append(filenames, files...)
 		} else {
 			file, err := fs.Open(filename)
 			if err != nil {
-				fmt.Fprintf(os.Stderr, "[!] Error opening file %s\n", filename)
+				fmt.Fprintf(os.Stderr, "[!] Error opening file %s.\n", filename)
 				os.Exit(1)
 			}
 			defer file.Close()
@@ -68,7 +68,7 @@ func ReadFilesToMap(fs models.FileSystem, filenames []string) map[string]int {
 			for {
 				bytesRead, err := file.Read(buffer)
 				if err != nil && err != io.EOF {
-					fmt.Fprintf(os.Stderr, "[!] Error reading file %s\n", filename)
+					fmt.Fprintf(os.Stderr, "[!] Error reading file %s.\n", filename)
 					os.Exit(1)
 				}
 				if bytesRead == 0 {
@@ -188,7 +188,7 @@ func ReadURLsToMap(urls []string, parsingMode int, debugMode int) (map[string]in
 
 			parsedURL, err := url.Parse(iURL)
 			if err != nil {
-				fmt.Println("Error parsing URL:", err)
+				fmt.Println("[!] Error parsing URL:", err)
 				continue
 			}
 			if parsedURL.Host == prevURL {
@@ -214,7 +214,7 @@ func ReadURLsToMap(urls []string, parsingMode int, debugMode int) (map[string]in
 			wg.Add(1)
 			go ProcessURLFile(iURL, ch, &wg, parsingMode, debugMode)
 		} else {
-			fmt.Fprintf(os.Stderr, "[!] Rejected URL or file: %s\n", iURL)
+			fmt.Fprintf(os.Stderr, "[!] Rejected URL or file: %s.\n", iURL)
 			return nil, fmt.Errorf("invalid input: %s", iURL)
 		}
 	}
@@ -311,14 +311,14 @@ func ProcessURL(url string, ch chan<- string, wg *sync.WaitGroup, parsingMode in
 		resp, err = client.Do(req)
 		if err != nil {
 			if debugMode >= 2 {
-				fmt.Fprintf(os.Stderr, "[!] Error fetching URL %s\n", url)
+				fmt.Fprintf(os.Stderr, "[!] Error fetching URL %s.\n", url)
 			}
 			return
 		}
 
 		if resp == nil {
 			if debugMode >= 2 {
-				fmt.Fprintf(os.Stderr, "[!] Error no response from URL %s\n", url)
+				fmt.Fprintf(os.Stderr, "[!] Error no response from URL %s.\n", url)
 			}
 			return
 		}
@@ -359,7 +359,7 @@ func ProcessURL(url string, ch chan<- string, wg *sync.WaitGroup, parsingMode in
 
 	if resp == nil {
 		if debugMode >= 1 {
-			fmt.Fprintf(os.Stderr, "[!] Error no response from URL %s\n", url)
+			fmt.Fprintf(os.Stderr, "[!] Error no response from URL %s.\n", url)
 		}
 		return
 	}
@@ -367,7 +367,7 @@ func ProcessURL(url string, ch chan<- string, wg *sync.WaitGroup, parsingMode in
 	body, err := io.ReadAll(resp.Body)
 	if err != nil {
 		if debugMode >= 1 {
-			fmt.Fprintf(os.Stderr, "[!] Error reading response body from URL %s\n", url)
+			fmt.Fprintf(os.Stderr, "[!] Error reading response body from URL %s.\n", url)
 		}
 		return
 	}
@@ -382,7 +382,7 @@ func ProcessURL(url string, ch chan<- string, wg *sync.WaitGroup, parsingMode in
 		doc, err := html.Parse(strings.NewReader(text))
 		if err != nil {
 			if debugMode >= 1 {
-				fmt.Fprintf(os.Stderr, "[!] Error parsing HTML from URL %s\n", url)
+				fmt.Fprintf(os.Stderr, "[!] Error parsing HTML from URL %s.\n", url)
 			}
 			return
 		}
@@ -584,19 +584,19 @@ func ReadJSONToArray(fs models.FileSystem, filenames []string) []models.Template
 				return nil
 			})
 			if err != nil {
-				fmt.Fprintf(os.Stderr, "[!] Error walking the path %v: %v\n", filename, err)
+				fmt.Fprintf(os.Stderr, "[!] Error walking the path %v: %v.\n", filename, err)
 				os.Exit(1)
 			}
 		} else {
 			data, err := fs.ReadFile(filename)
 			if err != nil {
-				fmt.Fprintf(os.Stderr, "[!] Error reading file %s\n", filename)
+				fmt.Fprintf(os.Stderr, "[!] Error reading file %s.\n", filename)
 				os.Exit(1)
 			}
 
 			err = json.Unmarshal(data, &template)
 			if err != nil {
-				fmt.Fprintf(os.Stderr, "[!] Error unmarshalling JSON file %s\n", filename)
+				fmt.Fprintf(os.Stderr, "[!] Error unmarshalling JSON file %s.\n", filename)
 				os.Exit(1)
 			}
 
@@ -610,32 +610,32 @@ func ReadJSONToArray(fs models.FileSystem, filenames []string) []models.Template
 
 	for _, template := range combinedTemplate {
 		if !numRe.MatchString(fmt.Sprintf("%v", template.StartIndex)) || !numRe.MatchString(fmt.Sprintf("%v", template.EndIndex)) {
-			fmt.Fprintf(os.Stderr, "[!] Error: StartIndex and EndIndex must be integers\n")
+			fmt.Fprintf(os.Stderr, "[!] Error: StartIndex and EndIndex must be integers.\n")
 			os.Exit(1)
 		}
 
 		if !alphaRe.MatchString(fmt.Sprintf("%v", template.Verbose)) {
-			fmt.Fprintf(os.Stderr, "[!] Error: Verbose must be a boolean\n")
+			fmt.Fprintf(os.Stderr, "[!] Error: Verbose must be a boolean.\n")
 			os.Exit(1)
 		}
 
 		if !alphaRe.MatchString(fmt.Sprintf("%v", template.ReplacementMask)) {
-			fmt.Fprintf(os.Stderr, "[!] Error: ReplacementMask must be a string\n")
+			fmt.Fprintf(os.Stderr, "[!] Error: ReplacementMask must be a string.\n")
 			os.Exit(1)
 		}
 
 		if !alphaRe.MatchString(fmt.Sprintf("%v", template.Bypass)) {
-			fmt.Fprintf(os.Stderr, "[!] Error: Bypass must be a boolean\n")
+			fmt.Fprintf(os.Stderr, "[!] Error: Bypass must be a boolean.\n")
 			os.Exit(1)
 		}
 
 		if !alphaRe.MatchString(fmt.Sprintf("%v", template.TransformationMode)) {
-			fmt.Fprintf(os.Stderr, "[!] Error: TransformationMode must be a string\n")
+			fmt.Fprintf(os.Stderr, "[!] Error: TransformationMode must be a string.\n")
 			os.Exit(1)
 		}
 
 		if !numRe.MatchString(fmt.Sprintf("%v", template.PassphraseWords)) {
-			fmt.Fprintf(os.Stderr, "[!] Error: PassphraseWords must be an integer\n")
+			fmt.Fprintf(os.Stderr, "[!] Error: PassphraseWords must be an integer.\n")
 			os.Exit(1)
 		}
 	}
@@ -663,7 +663,7 @@ func ProcessURLFile(filePath string, ch chan<- string, wg *sync.WaitGroup, parsi
 
 	file, err := os.Open(filePath)
 	if err != nil {
-		fmt.Fprintf(os.Stderr, "[!] Error opening file %v: %v\n", filePath, err)
+		fmt.Fprintf(os.Stderr, "[!] Error opening file %v: %v.\n", filePath, err)
 		return
 	}
 	defer file.Close()
@@ -675,7 +675,7 @@ func ProcessURLFile(filePath string, ch chan<- string, wg *sync.WaitGroup, parsi
 
 			parsedURL, err := url.Parse(line)
 			if err != nil {
-				fmt.Println("Error parsing URL:", err)
+				fmt.Println("[!] Error parsing URL:", err)
 				continue
 			}
 			if parsedURL.Host == prevURL {
@@ -688,12 +688,12 @@ func ProcessURLFile(filePath string, ch chan<- string, wg *sync.WaitGroup, parsi
 			wg.Add(1)
 			go ProcessURL(line, ch, wg, parsingMode, debugMode, sleepOnStart)
 		} else {
-			fmt.Fprintf(os.Stderr, "[!] Rejected URL: %s\n", line)
+			fmt.Fprintf(os.Stderr, "[!] Rejected URL: %s.\n", line)
 		}
 	}
 
 	if err := scanner.Err(); err != nil {
-		fmt.Fprintf(os.Stderr, "[!] Error reading file %v: %v\n", filePath, err)
+		fmt.Fprintf(os.Stderr, "[!] Error reading file %v: %v.\n", filePath, err)
 	}
 }
 
@@ -944,7 +944,7 @@ func SubstringMap(sMap map[string]int, sIndex int, eIndex int, bypass bool, debu
 		maxLen := eIndex
 		if sIndex > len(s) {
 			if debug {
-				fmt.Fprintf(os.Stderr, fmt.Sprintf("[!] Error: Start index is out of bounds: %s\n", s))
+				fmt.Fprintf(os.Stderr, fmt.Sprintf("[!] Error: Start index is out of bounds: %s.\n", s))
 			}
 			continue
 		} else if eIndex > len(s) {

--- a/pkg/utils/utils_test.go
+++ b/pkg/utils/utils_test.go
@@ -674,7 +674,7 @@ func TestGeneratePassphrase(t *testing.T) {
 
 	// Define test cases
 	testCases := TestCases{
-		{"I <3 you", 3, []string{"I<3you", "I<3YOU", "i<3you", "I<3YOU", "I<3You", "i<3you", "i<3you", "I<3YOU"}},
+		{"I <3 you", 3, []string{"I<3you", "I<3YOU", "i<3you", "I<3YOU", "I<3You", "i<3you", "i<3you", "I<3YOU", "I-<3-You", "I-<3-YOU", "I_<3_YOU", "I_<3_You"}},
 	}
 
 	// Run test cases


### PR DESCRIPTION
- Accidentally committed the rework of `passphrase` to main. Whoops!
- Documentation updates and aligning program output with user expectations

- Redid the `passphrase` mode to expect an input of space separated text that it will mutate into passphrase-like strings instead of randomized passphrase generation. This will make it more compatible with other modes for the program and create new attack paths.