### PR TITLE
V0.3.5

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,7 +40,7 @@ git clone https://github.com/JakeWnuk/ptt && cd ptt && docker build -t ptt . && 
 
 ### Usage:
 ```
-Usage of Password Transformation Tool (ptt) version (0.3.4):
+Usage of Password Transformation Tool (ptt) version (0.3.5):
 
 ptt [options] [...]
 Accepts standard input and/or additonal arguments.
@@ -86,8 +86,8 @@ These modify or filter the transformation mode.
         Show statistics output when possible.
   -vvv
         Show verbose statistics output when possible.
-  -w int
-        Number of words to use for a transformation if applicable.
+  -w value
+        Number of words for transformations if applicable. Accepts ranges separated by '-'.
 -------------------------------------------------------------------------------------------------------------
 Transformation Modes:
 These create or alter based on the selected mode.

--- a/README.md
+++ b/README.md
@@ -50,7 +50,7 @@ The -f, -k, -r, -tf, -tp, and -u flags can be used multiple times, together, and
 Options:
 These modify or filter the transformation mode.
 
-  -b    Bypass map creation and use stdout as primary output.
+  -b    Bypass map creation and use stdout as primary output. Disables some options.
   -d int
         Enable debug mode with verbosity levels [0-2].
   -f value
@@ -66,7 +66,7 @@ These modify or filter the transformation mode.
   -n int
         Maximum number of items to return in output.
   -o string
-        Output to JSON file in addition to stdout.
+        Output to JSON file in addition to stdout. Accepts file names and paths.
   -p int
         Change parsing mode for URL input. [0 = Strict, 1 = Permissive, 2 = Maximum] [0-2].
   -r value
@@ -78,10 +78,10 @@ These modify or filter the transformation mode.
   -tf value
         Read additional files for transformations if applicable.
   -tp value
-        Read a template file for multiple transformations and operations.
+        Read a template file for multiple transformations and operations. Cannot be used with -t flag.
   -u value
         Read additional URLs for input.
-  -v    Show verbose output when possible.
+  -v    Show verbose output when possible. (Can show additional metadata in some modes.)
   -vv
         Show statistics output when possible.
   -vvv
@@ -119,21 +119,21 @@ These create or alter based on the selected mode.
   -t replace-all -tf [file]
         Transforms input by replacing all strings with all matches from a ':' separated file.
   -t rule-append
-        Transforms input into append rules.
+        Transforms input by creating append rules.
   -t rule-append-remove
-        Transforms input into append-remove rules.
+        Transforms input by creating append-remove rules.
   -t rule-insert -i [index]
-        Transforms input into insert rules starting at index.
+        Transforms input by creating insert rules starting at index.
   -t rule-overwrite -i [index]
-        Transforms input into overwrite rules starting at index.
+        Transforms input by creating overwrite rules starting at index.
   -t rule-prepend
-        Transforms input into prepend rules.
+        Transforms input by creating prepend rules.
   -t rule-prepend-remove
-        Transforms input into prepend-remove rules.
+        Transforms input by creating prepend-remove rules.
   -t rule-prepend-toggle
-        Transforms input into prepend-toggle rules. Creating camelCase and PascalCase.
+        Transforms input by creating prepend-toggle rules.
   -t rule-toggle -i [index]
-        Transforms input into toggle rules starting at index.
+        Transforms input by creating toggle rules starting at index.
   -t substring -i [index]
         Transforms input by extracting substrings starting at index and ending at index.
   -t swap-single -tf [file]

--- a/docs/USAGE.md
+++ b/docs/USAGE.md
@@ -150,8 +150,8 @@ These flags work with files and directories.
         Show statistics output when possible.
   -vvv
         Show verbose statistics output when possible.
-  -w int
-        Number of words to use for a transformation if applicable.
+  -w value
+        Number of words for transformations if applicable. Accepts ranges separated by '-'.
 ```
 
 #### Transformations:

--- a/docs/USAGE.md
+++ b/docs/USAGE.md
@@ -1,5 +1,5 @@
 # Password Transformation Tool (PTT) Usage Guide
-## Version 0.3.4
+## Version 0.3.5
 
 ### Table of Contents
 #### Getting Started
@@ -114,7 +114,7 @@ These flags work with files and directories.
 
 #### Options:
 ```
-  -b    Bypass map creation and use stdout as primary output.
+  -b    Bypass map creation and use stdout as primary output. Disables some options.
   -d int
         Enable debug mode with verbosity levels [0-2].
   -f value
@@ -130,7 +130,7 @@ These flags work with files and directories.
   -n int
         Maximum number of items to return in output.
   -o string
-        Output to JSON file in addition to stdout.
+        Output to JSON file in addition to stdout. Accepts file names and paths.
   -p int
         Change parsing mode for URL input. [0 = Strict, 1 = Permissive, 2 = Maximum] [0-2].
   -r value
@@ -142,10 +142,10 @@ These flags work with files and directories.
   -tf value
         Read additional files for transformations if applicable.
   -tp value
-        Read a template file for multiple transformations and operations.
+        Read a template file for multiple transformations and operations. Cannot be used with -t flag.
   -u value
         Read additional URLs for input.
-  -v    Show verbose output when possible.
+  -v    Show verbose output when possible. (Can show additional metadata in some modes.)
   -vv
         Show statistics output when possible.
   -vvv
@@ -184,21 +184,21 @@ The following transformations can be used with the `-t` flag:
   -t replace-all -tf [file]
         Transforms input by replacing all strings with all matches from a ':' separated file.
   -t rule-append
-        Transforms input into append rules.
+        Transforms input by creating append rules.
   -t rule-append-remove
-        Transforms input into append-remove rules.
+        Transforms input by creating append-remove rules.
   -t rule-insert -i [index]
-        Transforms input into insert rules starting at index.
+        Transforms input by creating insert rules starting at index.
   -t rule-overwrite -i [index]
-        Transforms input into overwrite rules starting at index.
+        Transforms input by creating overwrite rules starting at index.
   -t rule-prepend
-        Transforms input into prepend rules.
+        Transforms input by creating prepend rules.
   -t rule-prepend-remove
-        Transforms input into prepend-remove rules.
+        Transforms input by creating prepend-remove rules.
   -t rule-prepend-toggle
-        Transforms input into prepend-toggle rules. Creating camelCase and PascalCase.
+        Transforms input by creating prepend-toggle rules.
   -t rule-toggle -i [index]
-        Transforms input into toggle rules starting at index.
+        Transforms input by creating toggle rules starting at index.
   -t substring -i [index]
         Transforms input by extracting substrings starting at index and ending at index.
   -t swap-single -tf [file]

--- a/docs/template.json
+++ b/docs/template.json
@@ -6,7 +6,8 @@
         "ReplacementMask": "uldsb",
         "Bypass": false,
         "TransformationMode": "mask",
-        "PassphraseWords": 0
+        "WordRangeStart": 0,
+        "WordRangeEnd": 0
     },
     {
         "StartIndex": 0,
@@ -15,6 +16,7 @@
         "ReplacementMask": "dsb",
         "Bypass": false,
         "TransformationMode": "mask",
-        "PassphraseWords": 0
+        "WordRangeStart": 0,
+        "WordRangeEnd": 0
     }
 ]

--- a/main.go
+++ b/main.go
@@ -95,6 +95,7 @@ func main() {
 	debugMode := flag.Int("d", 0, "Enable debug mode with verbosity levels [0-2].")
 	URLParsingMode := flag.Int("p", 0, "Change parsing mode for URL input. [0 = Strict, 1 = Permissive, 2 = Maximum] [0-2].")
 	// TODO -w should accept a range and documentation should reflect it
+	// (update templates if needed)
 	passPhraseWords := flag.Int("w", 0, "Number of words to use for a transformation if applicable.")
 	flag.Var(&retain, "k", "Only keep items in a file.")
 	flag.Var(&remove, "r", "Only keep items not in a file.")

--- a/main.go
+++ b/main.go
@@ -44,14 +44,14 @@ func main() {
 		fmt.Fprintln(os.Stderr, "\nTransformation Modes:")
 		fmt.Fprintf(os.Stderr, "These create or alter based on the selected mode.\n\n")
 		modes := map[string]string{
-			"rule-append":                        "Transforms input into append rules.",
-			"rule-append-remove":                 "Transforms input into append-remove rules.",
-			"rule-prepend":                       "Transforms input into prepend rules.",
-			"rule-prepend-remove":                "Transforms input into prepend-remove rules.",
-			"rule-prepend-toggle":                "Transforms input into prepend-toggle rules. Creating camelCase and PascalCase.",
-			"rule-insert -i [index]":             "Transforms input into insert rules starting at index.",
-			"rule-overwrite -i [index]":          "Transforms input into overwrite rules starting at index.",
-			"rule-toggle -i [index]":             "Transforms input into toggle rules starting at index.",
+			"rule-append":                        "Transforms input by creating append rules.",
+			"rule-append-remove":                 "Transforms input by creating append-remove rules.",
+			"rule-prepend":                       "Transforms input by creating prepend rules.",
+			"rule-prepend-remove":                "Transforms input by creating prepend-remove rules.",
+			"rule-prepend-toggle":                "Transforms input by creating prepend-toggle rules.",
+			"rule-insert -i [index]":             "Transforms input by creating insert rules starting at index.",
+			"rule-overwrite -i [index]":          "Transforms input by creating overwrite rules starting at index.",
+			"rule-toggle -i [index]":             "Transforms input by creating toggle rules starting at index.",
 			"encode":                             "Transforms input by HTML and Unicode escape encoding.",
 			"decode":                             "Transforms input by HTML and Unicode escape decoding.",
 			"hex":                                "Transforms input by encoding strings into $HEX[...] format.",
@@ -84,22 +84,22 @@ func main() {
 	}
 
 	// Define command line flags
-	verbose := flag.Bool("v", false, "Show verbose output when possible.")
+	verbose := flag.Bool("v", false, "Show verbose output when possible. (Can show additional metadata in some modes.)")
 	verbose2 := flag.Bool("vv", false, "Show statistics output when possible.")
 	verbose3 := flag.Bool("vvv", false, "Show verbose statistics output when possible.")
 	minimum := flag.Int("m", 0, "Minimum numerical frequency to include in output.")
 	outputVerboseMax := flag.Int("n", 0, "Maximum number of items to return in output.")
 	transformation := flag.String("t", "", "Transformation to apply to input.")
 	replacementMask := flag.String("rm", "uldsbt", "Replacement mask for transformations if applicable.")
-	jsonOutput := flag.String("o", "", "Output to JSON file in addition to stdout.")
-	bypassMap := flag.Bool("b", false, "Bypass map creation and use stdout as primary output.")
+	jsonOutput := flag.String("o", "", "Output to JSON file in addition to stdout. Accepts file names and paths.")
+	bypassMap := flag.Bool("b", false, "Bypass map creation and use stdout as primary output. Disables some options.")
 	debugMode := flag.Int("d", 0, "Enable debug mode with verbosity levels [0-2].")
 	URLParsingMode := flag.Int("p", 0, "Change parsing mode for URL input. [0 = Strict, 1 = Permissive, 2 = Maximum] [0-2].")
 	flag.Var(&retain, "k", "Only keep items in a file.")
 	flag.Var(&remove, "r", "Only keep items not in a file.")
 	flag.Var(&readFiles, "f", "Read additional files for input.")
 	flag.Var(&transformationFiles, "tf", "Read additional files for transformations if applicable.")
-	flag.Var(&templateFiles, "tp", "Read a template file for multiple transformations and operations.")
+	flag.Var(&templateFiles, "tp", "Read a template file for multiple transformations and operations. Cannot be used with -t flag.")
 	flag.Var(&intRange, "i", "Starting index for transformations if applicable. Accepts ranges separated by '-'.")
 	flag.Var(&lenRange, "l", "Only output items of a certain length (does not adjust for rules). Accepts ranges separated by '-'.")
 	flag.Var(&wordRange, "w", "Number of words for transformations if applicable. Accepts ranges separated by '-'.")

--- a/main.go
+++ b/main.go
@@ -40,8 +40,8 @@ func main() {
 		fmt.Fprintf(os.Stderr, "Options:\n")
 		fmt.Fprintf(os.Stderr, "These modify or filter the transformation mode.\n\n")
 		flag.PrintDefaults()
-		fmt.Fprintf(os.Stderr, "-------------------------------------------------------------------------------------------------------------")
-		fmt.Fprintln(os.Stderr, "\nTransformation Modes:")
+		fmt.Fprintf(os.Stderr, "-------------------------------------------------------------------------------------------------------------\n")
+		fmt.Fprintf(os.Stderr, "Transformation Modes:\n")
 		fmt.Fprintf(os.Stderr, "These create or alter based on the selected mode.\n\n")
 		modes := map[string]string{
 			"rule-append":                        "Transforms input by creating append rules.",

--- a/main.go
+++ b/main.go
@@ -26,6 +26,7 @@ var transformationFiles models.FileArgumentFlag
 var templateFiles models.FileArgumentFlag
 var intRange models.IntRange
 var lenRange models.IntRange
+var wordRange models.IntRange
 var primaryMap map[string]int
 var err error
 
@@ -94,9 +95,6 @@ func main() {
 	bypassMap := flag.Bool("b", false, "Bypass map creation and use stdout as primary output.")
 	debugMode := flag.Int("d", 0, "Enable debug mode with verbosity levels [0-2].")
 	URLParsingMode := flag.Int("p", 0, "Change parsing mode for URL input. [0 = Strict, 1 = Permissive, 2 = Maximum] [0-2].")
-	// TODO -w should accept a range and documentation should reflect it
-	// (update templates if needed)
-	passPhraseWords := flag.Int("w", 0, "Number of words to use for a transformation if applicable.")
 	flag.Var(&retain, "k", "Only keep items in a file.")
 	flag.Var(&remove, "r", "Only keep items not in a file.")
 	flag.Var(&readFiles, "f", "Read additional files for input.")
@@ -104,6 +102,7 @@ func main() {
 	flag.Var(&templateFiles, "tp", "Read a template file for multiple transformations and operations.")
 	flag.Var(&intRange, "i", "Starting index for transformations if applicable. Accepts ranges separated by '-'.")
 	flag.Var(&lenRange, "l", "Only output items of a certain length (does not adjust for rules). Accepts ranges separated by '-'.")
+	flag.Var(&wordRange, "w", "Number of words for transformations if applicable. Accepts ranges separated by '-'.")
 	flag.Var(&readURLs, "u", "Read additional URLs for input.")
 	flag.Parse()
 
@@ -168,7 +167,7 @@ func main() {
 
 	// Apply transformation if provided
 	if *transformation != "" && templateFiles == nil {
-		primaryMap = transform.TransformationController(primaryMap, *transformation, intRange.Start, intRange.End, *verbose, *replacementMask, transformationFilesMap, *bypassMap, *debugMode, *passPhraseWords)
+		primaryMap = transform.TransformationController(primaryMap, *transformation, intRange.Start, intRange.End, *verbose, *replacementMask, transformationFilesMap, *bypassMap, *debugMode, wordRange.Start, wordRange.End)
 	} else if templateFiles != nil && *transformation == "" {
 		fmt.Fprintf(os.Stderr, "[*] Using template files for multiple transformations.\n")
 
@@ -181,9 +180,9 @@ func main() {
 		// Apply transformations from template files
 		for i, template := range transformationTemplateArray {
 			if i == 0 {
-				temporaryMap = transform.TransformationController(primaryMap, template.TransformationMode, template.StartIndex, template.EndIndex, template.Verbose, template.ReplacementMask, transformationFilesMap, template.Bypass, *debugMode, template.PassphraseWords)
+				temporaryMap = transform.TransformationController(primaryMap, template.TransformationMode, template.StartIndex, template.EndIndex, template.Verbose, template.ReplacementMask, transformationFilesMap, template.Bypass, *debugMode, template.WordRangeStart, template.WordRangeEnd)
 			} else {
-				temporaryMap = utils.CombineMaps(temporaryMap, transform.TransformationController(primaryMap, template.TransformationMode, template.StartIndex, template.EndIndex, template.Verbose, template.ReplacementMask, transformationFilesMap, template.Bypass, *debugMode, template.PassphraseWords))
+				temporaryMap = utils.CombineMaps(temporaryMap, transform.TransformationController(primaryMap, template.TransformationMode, template.StartIndex, template.EndIndex, template.Verbose, template.ReplacementMask, transformationFilesMap, template.Bypass, *debugMode, template.WordRangeStart, template.WordRangeEnd))
 			}
 		}
 		primaryMap = temporaryMap

--- a/main.go
+++ b/main.go
@@ -123,6 +123,11 @@ func main() {
 	var readFilesMap map[string]int
 	var transformationFilesMap map[string]int
 
+	// Read files if provided
+	if retain != nil || remove != nil || readFiles != nil || transformationFiles != nil {
+		fmt.Fprintf(os.Stderr, "[*] Reading files for input.\n")
+	}
+
 	if retain != nil {
 		retainMap = utils.ReadFilesToMap(fs, retain)
 	}

--- a/main.go
+++ b/main.go
@@ -15,7 +15,7 @@ import (
 	"github.com/jakewnuk/ptt/pkg/utils"
 )
 
-var version = "0.3.4"
+var version = "0.3.5"
 var wg sync.WaitGroup
 var mutex = &sync.Mutex{}
 var retain models.FileArgumentFlag
@@ -94,6 +94,7 @@ func main() {
 	bypassMap := flag.Bool("b", false, "Bypass map creation and use stdout as primary output.")
 	debugMode := flag.Int("d", 0, "Enable debug mode with verbosity levels [0-2].")
 	URLParsingMode := flag.Int("p", 0, "Change parsing mode for URL input. [0 = Strict, 1 = Permissive, 2 = Maximum] [0-2].")
+	// TODO -w should accept a range and documentation should reflect it
 	passPhraseWords := flag.Int("w", 0, "Number of words to use for a transformation if applicable.")
 	flag.Var(&retain, "k", "Only keep items in a file.")
 	flag.Var(&remove, "r", "Only keep items not in a file.")

--- a/pkg/mask/mask.go
+++ b/pkg/mask/mask.go
@@ -471,11 +471,7 @@ func ShuffleMap(input map[string]int, replacementMask string, swapMap map[string
 			if maskedSwapKey == newKey || fmt.Sprintf("%s%s", maskedSwapKey, maskedSwapKey) == newKey {
 
 				var shufKey string
-				if fmt.Sprintf("%s%s", maskedSwapKey, maskedSwapKey) == newKey {
-					shufKey = strings.Replace(key, maskedSwapKey, swapKey, 2)
-				} else {
-					shufKey = strings.Replace(key, newKey, swapKey, 1)
-				}
+				shufKey = strings.Replace(key, newKey, swapKey, 1)
 
 				if debug {
 					fmt.Fprintf(os.Stderr, "[?][?] Swap performed:\n")
@@ -484,6 +480,12 @@ func ShuffleMap(input map[string]int, replacementMask string, swapMap map[string
 				}
 
 				if shufKey == key {
+					if debug {
+						fmt.Fprintf(os.Stderr, "[?][?] Swap failed identical keys:\n")
+						fmt.Fprintf(os.Stderr, "Key: %s\n", key)
+						fmt.Fprintf(os.Stderr, "Swap Result: %s\n", shufKey)
+					}
+
 					continue
 				}
 

--- a/pkg/mask/mask.go
+++ b/pkg/mask/mask.go
@@ -445,7 +445,7 @@ func BoundarySplitPopMap(input map[string]int, replacementMask string, bypass bo
 func ShuffleMap(input map[string]int, replacementMask string, swapMap map[string]int, bypass bool, debug bool) map[string]int {
 	shuffleMap := make(map[string]int)
 	re := regexp.MustCompile(`^(\?u|\?l|\?d|\?s|\?b)*$`)
-	reParser := regexp.MustCompile("(\\?[luds])")
+	reParser := regexp.MustCompile("(\\?[ludsb])")
 
 	for key, value := range input {
 		newKey := ""
@@ -468,7 +468,7 @@ func ShuffleMap(input map[string]int, replacementMask string, swapMap map[string
 			}
 
 			maskedSwapKey := MakeMaskedString(swapKey, replacementMask)
-			if maskedSwapKey == newKey || fmt.Sprintf("%s%s", maskedSwapKey, maskedSwapKey) == newKey {
+			if maskedSwapKey == newKey {
 
 				var shufKey string
 				shufKey = strings.Replace(key, newKey, swapKey, 1)

--- a/pkg/mask/mask.go
+++ b/pkg/mask/mask.go
@@ -462,7 +462,7 @@ func ShuffleMap(input map[string]int, replacementMask string, swapMap map[string
 			if debug {
 				fmt.Fprintf(os.Stderr, "[?] ShuffleMap:\n")
 				fmt.Fprintf(os.Stderr, "Key: %s\n", key)
-				fmt.Fprintf(os.Stderr, "New Key: %s\n", newKey)
+				fmt.Fprintf(os.Stderr, "Match: %s\n", match)
 				fmt.Fprintf(os.Stderr, "Swap Key: %s\n", swapKey)
 				fmt.Fprintf(os.Stderr, "Replacement Mask: %s\n", replacementMask)
 			}

--- a/pkg/mask/mask.go
+++ b/pkg/mask/mask.go
@@ -463,7 +463,7 @@ func ShuffleMap(input map[string]int, replacementMask string, swapMap map[string
 				fmt.Fprintf(os.Stderr, "[?] ShuffleMap:\n")
 				fmt.Fprintf(os.Stderr, "Key: %s\n", key)
 				fmt.Fprintf(os.Stderr, "Match: %s\n", match)
-				fmt.Fprintf(os.Stderr, "Swap Key: %s\n", swapKey)
+				fmt.Fprintf(os.Stderr, "Swap Token: %s\n", swapKey)
 				fmt.Fprintf(os.Stderr, "Replacement Mask: %s\n", replacementMask)
 			}
 
@@ -478,8 +478,9 @@ func ShuffleMap(input map[string]int, replacementMask string, swapMap map[string
 				}
 
 				if debug {
-					fmt.Fprintf(os.Stderr, "Masked Swap Key: %s\n", maskedSwapKey)
-					fmt.Fprintf(os.Stderr, "Shuffle Key: %s\n", shufKey)
+					fmt.Fprintf(os.Stderr, "[?][?] Swap performed:\n")
+					fmt.Fprintf(os.Stderr, "Swap Token Mask: %s\n", maskedSwapKey)
+					fmt.Fprintf(os.Stderr, "Swap Result: %s\n", shufKey)
 				}
 
 				if shufKey == key {

--- a/pkg/mask/mask_test.go
+++ b/pkg/mask/mask_test.go
@@ -305,7 +305,7 @@ func TestShuffleMap(t *testing.T) {
 	// Define test cases
 	tests := testCases{
 		{map[string]int{"abc?d?d?d": 1, "?u?u?u456": 2, "ABC?l?l?l123!!!": 3}, "luds", map[string]int{"DEF": 1, "321": 1, "zxc": 1}, map[string]int{"ABCzxc123!!!": 3, "DEF456": 2, "abc321": 1}},
-		{map[string]int{"?d?d?dabc?d?d?d": 1, "123?l?l?l": 2, "ABC?l?l?l123!!!": 3}, "luds", map[string]int{"DEF": 1, "321": 1, "zxc": 1}, map[string]int{"123zxc": 2, "ABCzxc123!!!": 3, "321abc321": 1}},
+		{map[string]int{"?d?d?dabc?d?d?d": 1, "123?l?l?l": 2, "ABC?l?l?l123!!!": 3}, "luds", map[string]int{"DEF": 1, "321": 1, "zxc": 1}, map[string]int{"123zxc": 2, "ABCzxc123!!!": 3}},
 	}
 
 	// Run test cases

--- a/pkg/models/models.go
+++ b/pkg/models/models.go
@@ -63,7 +63,8 @@ type TemplateFileOperation struct {
 	ReplacementMask    string
 	Bypass             bool
 	TransformationMode string
-	PassphraseWords    int
+	WordRangeStart     int
+	WordRangeEnd       int
 }
 
 // ----------------------------------------------------------------------------
@@ -158,7 +159,7 @@ func (r *RealFileSystem) ReadFile(filename string) ([]byte, error) {
 }
 
 // Open opens a file and returns a File interface
-func (fs RealFileSystem) Open(filename string) (File, error) {
+func (r RealFileSystem) Open(filename string) (File, error) {
 	return os.Open(filename)
 }
 

--- a/pkg/utils/utils.go
+++ b/pkg/utils/utils.go
@@ -43,7 +43,6 @@ import (
 func ReadFilesToMap(fs models.FileSystem, filenames []string) map[string]int {
 	wordMap := make(map[string]int)
 	// 1 GB read buffer
-	fmt.Fprintf(os.Stderr, "[*] Creating buffer and reading file...\n")
 	chunkSize := int64(1 * 1024 * 1024 * 1024)
 
 	i := 0

--- a/pkg/utils/utils.go
+++ b/pkg/utils/utils.go
@@ -42,9 +42,9 @@ import (
 //	(map[string]int): A map of words from the files
 func ReadFilesToMap(fs models.FileSystem, filenames []string) map[string]int {
 	wordMap := make(map[string]int)
-	// 4 GB read buffer
+	// 2 GB read buffer
 	fmt.Fprintf(os.Stderr, "[*] Creating buffer and reading file...\n")
-	chunkSize := int64(4 * 1024 * 1024 * 1024)
+	chunkSize := int64(2 * 1024 * 1024 * 1024)
 
 	i := 0
 	for i < len(filenames) {

--- a/pkg/utils/utils.go
+++ b/pkg/utils/utils.go
@@ -634,8 +634,8 @@ func ReadJSONToArray(fs models.FileSystem, filenames []string) []models.Template
 			os.Exit(1)
 		}
 
-		if !numRe.MatchString(fmt.Sprintf("%v", template.PassphraseWords)) {
-			fmt.Fprintf(os.Stderr, "[!] Error: PassphraseWords must be an integer.\n")
+		if !numRe.MatchString(fmt.Sprintf("%v", template.WordRangeStart)) || !numRe.MatchString(fmt.Sprintf("%v", template.WordRangeEnd)) {
+			fmt.Fprintf(os.Stderr, "[!] Error: WordRangeStart and WordRangeEnd must be integers.\n")
 			os.Exit(1)
 		}
 	}

--- a/pkg/utils/utils.go
+++ b/pkg/utils/utils.go
@@ -42,9 +42,9 @@ import (
 //	(map[string]int): A map of words from the files
 func ReadFilesToMap(fs models.FileSystem, filenames []string) map[string]int {
 	wordMap := make(map[string]int)
-	// 2 GB read buffer
+	// 1 GB read buffer
 	fmt.Fprintf(os.Stderr, "[*] Creating buffer and reading file...\n")
-	chunkSize := int64(2 * 1024 * 1024 * 1024)
+	chunkSize := int64(1 * 1024 * 1024 * 1024)
 
 	i := 0
 	for i < len(filenames) {

--- a/templates/masks/mask.json
+++ b/templates/masks/mask.json
@@ -6,7 +6,8 @@
         "ReplacementMask": "ul",
         "Bypass": false,
         "TransformationMode": "mask",
-        "PassphraseWords": 0
+        "WordRangeStart": 0,
+        "WordRangeEnd": 0
     },
     {
         "StartIndex": 0,
@@ -15,7 +16,8 @@
         "ReplacementMask": "dsb",
         "Bypass": false,
         "TransformationMode": "mask",
-        "PassphraseWords": 0
+        "WordRangeStart": 0,
+        "WordRangeEnd": 0
     },
     {
         "StartIndex": 0,
@@ -24,6 +26,7 @@
         "ReplacementMask": "uldsb",
         "Bypass": false,
         "TransformationMode": "mask",
-        "PassphraseWords": 0
+        "WordRangeStart": 0,
+        "WordRangeEnd": 0
     }
 ]

--- a/templates/misc/swap-encode.json
+++ b/templates/misc/swap-encode.json
@@ -6,7 +6,8 @@
         "ReplacementMask": "uldsb",
         "Bypass": false,
         "TransformationMode": "swap",
-        "PassphraseWords": 0
+        "WordRangeStart": 0,
+        "WordRangeEnd": 0
     },
     {
         "StartIndex": 0,
@@ -15,6 +16,7 @@
         "ReplacementMask": "uldsb",
         "Bypass": false,
         "TransformationMode": "encode",
-        "PassphraseWords": 0
+        "WordRangeStart": 0,
+        "WordRangeEnd": 0
     }
 ]

--- a/templates/rules/append.json
+++ b/templates/rules/append.json
@@ -6,7 +6,8 @@
         "ReplacementMask": "uldsb",
         "Bypass": false,
         "TransformationMode": "append",
-        "PassphraseWords": 0
+        "WordRangeStart": 0,
+        "WordRangeEnd": 0
     },
     {
         "StartIndex": 0,
@@ -15,7 +16,8 @@
         "ReplacementMask": "uldsb",
         "Bypass": false,
         "TransformationMode": "append-remove",
-        "PassphraseWords": 0
+        "WordRangeStart": 0,
+        "WordRangeEnd": 0
     },
     {
         "StartIndex": 0,
@@ -24,6 +26,7 @@
         "ReplacementMask": "uldsb",
         "Bypass": false,
         "TransformationMode": "append-shift",
-        "PassphraseWords": 0
+        "WordRangeStart": 0,
+        "WordRangeEnd": 0
     }
 ]

--- a/templates/rules/insert1-6.json
+++ b/templates/rules/insert1-6.json
@@ -6,7 +6,8 @@
         "ReplacementMask": "uldsb",
         "Bypass": false,
         "TransformationMode": "insert",
-        "PassphraseWords": 0
+        "WordRangeStart": 0,
+        "WordRangeEnd": 0
     },
     {
         "StartIndex": 1,
@@ -15,6 +16,7 @@
         "ReplacementMask": "uldsb",
         "Bypass": false,
         "TransformationMode": "overwrite",
-        "PassphraseWords": 0    
+        "WordRangeStart": 0,
+        "WordRangeEnd": 0
     }
 ]

--- a/templates/rules/prepend.json
+++ b/templates/rules/prepend.json
@@ -6,7 +6,8 @@
         "ReplacementMask": "uldsb",
         "Bypass": false,
         "TransformationMode": "prepend",
-        "PassphraseWords": 0
+        "WordRangeStart": 0,
+        "WordRangeEnd": 0
     },
     {
         "StartIndex": 0,
@@ -15,7 +16,8 @@
         "ReplacementMask": "uldsb",
         "Bypass": false,
         "TransformationMode": "prepend-remove",
-        "PassphraseWords": 0
+        "WordRangeStart": 0,
+        "WordRangeEnd": 0
     },
     {
         "StartIndex": 0,
@@ -24,6 +26,7 @@
         "ReplacementMask": "uldsb",
         "Bypass": false,
         "TransformationMode": "prepend-shift",
-        "PassphraseWords": 0
+        "WordRangeStart": 0,
+        "WordRangeEnd": 0
     }
 ]


### PR DESCRIPTION
- Large documentation updates
- `-w` now accepts a range
- Bug fixes for `mask-swap`
    - Fixed a bug where `?b` was not included
    - Fixed a bug where token duplication checks were making invalid swaps
- Updated file buffer from 4 GB to 1 GB